### PR TITLE
Add-on parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,29 @@ It is highly recommended that this be customised for the computer being used; [f
 ## Multi-Select
 By default file-browser only opens/appends the single item that the cursor has selected. However, using the `Ctrl` keybinds specified above, it is possible to select multiple items to open all at once. Selected items are shown in a different colour to the cursor. When multiple items are selected, they will be appended after the currently selected file when using the ENTER commands. The currently selected (with the cursor) file will always be added first, regardless of if it is part of the multi-selection, and will follow replace/append behaviour as normal. Selected items will be appended to the playlist afterwards in the order that they appear on the screen.
 
-## DVD Browser
-My script [mpv-dvd-browser](https://github.com/CogentRedTester/mpv-dvd-browser) is designed to work as an add-on for this script. The script uses the `lsdvd` commandline utility to read and display the titles of DVDs in an interractive browser extremely similar to this one.
+## Add-ons
+Add-ons are extra scripts that add parsing support for non-native filesystems.
+They can be enabled by loading the add-on script normally and enabling the corresponding `script-opt`.
+
+Browsing filesystems provided by add-ons should feel identical to the normal handling of the script.
+
+### http-browser
+This add-on implements support for http/https file servers, specifically the directory indexes that apache servers dynamically generate.
+I don't know if this will work on different types of servers.
+
+Requires `curl` in the system PATH.
+
+### ftp-browser
+Planned
+
+### [DVD Browser](https://github.com/CogentRedTester/mpv-dvd-browser)
+This add-on is a little different from the others. dvd-browser is actually standalone, and has a number of other dvd related features that don't
+require the browser at all. However, there is a compatability mode that makes it act a lot like a normal addon.
+
+The script uses the `lsdvd` commandline utility to read and display the titles of DVDs in an interractive browser extremely similar to this one.
 The script also has numerous options to make DVD playback more enjoyable, such as automatic playlist management.
 
-To enable both scripts enable the option `dvd_browser` in `file_browser.conf`, and the associated `file_browser` option in `dvd_browser.conf`.
+To enable compatability mode enable the option `dvd_browser` in `file_browser.conf`, and the associated `file_browser` option in `dvd_browser.conf`.
 When both scripts are active attempting to enter the `--dvd-device` directory will automatically pass control to dvd-browser.
 Similarly, moving up a directory from dvd-browser will pass control back to file-browser.
 It is also important to always use the file-browser activation keybind. Both scripts use `MENU` as the default toggle command, so it will be necessary to explicitly specify which to use by putting `MENU script-binding browse-files` in input.conf.

--- a/addons/http-browser.lua
+++ b/addons/http-browser.lua
@@ -14,9 +14,7 @@ do
     local function _(hex) return char(tonumber(hex, 16)) end
 
     function decodeURI(s)
-        msg.debug('decoding string: ' .. s)
         s = gsub(s, '%%(%x%x)', _)
-        msg.debug('returning string: ' .. s)
         return s
     end
 end
@@ -59,9 +57,9 @@ end
 
 mp.register_script_message("browse-http", function(dir)
     local result = parse_http(dir)
-    if not result then
-        mp.commandv("script-message", "update-list-callback")
-    else
+    if result then
         mp.commandv("script-message", "update-list-callback", result)
+    else
+        mp.commandv("script-message", "update-list-callback")
     end
 end)

--- a/addons/http-browser.lua
+++ b/addons/http-browser.lua
@@ -1,0 +1,68 @@
+--[[
+    An addon for mpv-file-browser which adds support for apache http directory indexes
+]]--
+
+local mp = require 'mp'
+local msg = require 'mp.msg'
+local utils = require 'mp.utils'
+
+--https://stackoverflow.com/questions/132397/get-back-the-output-of-os-execute-in-lua
+function os.capture(cmd)
+    local f = assert(io.popen(cmd, 'r'))
+    local s = assert(f:read('*a'))
+    f:close()
+    return s
+  end
+
+--decodes a URL address
+--this piece of code was taken from: https://stackoverflow.com/questions/20405985/lua-decodeuri-luvit/20406960#20406960
+local decodeURI
+do
+    local char, gsub, tonumber = string.char, string.gsub, tonumber
+    local function _(hex) return char(tonumber(hex, 16)) end
+
+    function decodeURI(s)
+        msg.debug('decoding string: ' .. s)
+        s = gsub(s, '%%(%x%x)', _)
+        msg.debug('returning string: ' .. s)
+        return s
+    end
+end
+
+local function parse_http(directory)
+    msg.verbose(directory)
+
+    -- cmd.stdout = cmd.stdout:gsub("[\n\r]", ' ')
+    msg.trace("curl -k -l "..string.format("%q", directory).. ' | grep "<tr>"')
+    local html = os.capture("curl -k -l -s "..string.format("%q", directory).. ' | grep "href"' )
+
+    -- print(html)
+    if not html:find("%[PARENTDIR%]") then return end
+
+    local list = {}
+    for str in string.gmatch(html, "[^\r\n]+") do
+        local link = str:match('href="(.-)"')
+        local alt = str:match('alt="%[(.-)%]"')
+        msg.trace(alt..": "..link)
+
+        if not alt or not link then goto continue end
+        if alt == "PARENTDIR" or alt == "ICO" then goto continue end
+        if link:find("[:?<>|]") then goto continue end
+
+        table.insert(list, { name = link, type = (alt == "DIR" and "dir" or "file"), label = decodeURI(link) })
+
+        ::continue::
+    end
+
+    local json, _ = utils.format_json(list)
+    return json
+end
+
+mp.register_script_message("browse-http", function(dir)
+    local result = parse_http(dir)
+    if not result then
+        mp.commandv("script-message", "update-list-callback")
+    else
+        mp.commandv("script-message", "update-list-callback", result)
+    end
+end)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -160,7 +160,8 @@ local function sort(t)
         return ("%03d%s"):format(#r, r)
     end
 
-    table.sort(t, function(a,b) return a:lower():gsub("%d+",padnum) < b:lower():gsub("%d+",padnum) end)
+    --appends the letter d or f to the start of the comparison to sort directories and folders as well
+    table.sort(t, function(a,b) return a.type:sub(1,1)..a.name:lower():gsub("%d+",padnum) < b.type:sub(1,1)..b.name:lower():gsub("%d+",padnum) end)
     return t
 end
 
@@ -235,7 +236,6 @@ local function update_local_list()
     end
 
     --sorts folders and formats them into the list of directories
-    sort(list1)
     for i=1, #list1 do
         local item = list1[i]
         if (state.prev_directory == state.directory..item..'/') then list.selected = i end
@@ -251,7 +251,6 @@ local function update_local_list()
 
     --appends files to the list of directory items
     local list2 = utils.readdir(state.directory, 'files')
-    sort(list2)
     for i=1, #list2 do
         local item = list2[i]
 
@@ -268,6 +267,8 @@ local function update_local_list()
 
         ::continue::
     end
+
+    sort(list.list)
 
     --saves the latest directory at the top of the stack
     cache[#cache+1] = {directory = state.directory, table = list.list}
@@ -546,6 +547,7 @@ end)
 mp.register_script_message('update-list-callback', function(json)
     if not json then goto_root(); return end
     list.list = utils.parse_json(json)
+    sort(list.list)
 
     --setting up the cache stuff
     cache[#cache+1] = {directory = state.directory, table = list.list}

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -118,7 +118,7 @@ list.format_line = function(this, i, v)
     if v.type == 'dir' then this:append([[🖿\h]]) end
 
     --adds the actual name of the item
-    if state.directory == "" then this:append(v.label.."\\N")
+    if v.label then this:append(v.label.."\\N")
     else this:append(v.name.."\\N") end
 end
 
@@ -544,7 +544,7 @@ end)
 
 --a callback function for addon scripts to return the results of their filesystem processing
 mp.register_script_message('update-list-callback', function(json)
-    if not json then goto_root() end
+    if not json then goto_root(); return end
     list.list = utils.parse_json(json)
 
     --setting up the cache stuff


### PR DESCRIPTION
Implement add-on support and created `http-browser` addon.

add-ons can be enabled by loading the script normally and setting the
corresponding script-opt to true.