### PR TITLE
Implement Custom keybinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ By default file-browser only opens/appends the single item that the cursor has s
 File-browser also supports custom keybinds. These keybinds send normal input commands, but the script will substitute characters in the command strings for specific values depending on the currently open directory, and currently selected item.
 This allows for a wide range of customised behaviour, such as loading subtitle files from the browser, or copying the path of the selected item to the clipboard.
 
-The keybinds are declared in the `~~/script-opts/file-browser-keybinds.json` file, the config takes the form of an array of json objects, with the following keys:
+The feature is disabled by default, but is enabled with the `custom_keybinds` script-opt.
+Keybinds are declared in the `~~/script-opts/file-browser-keybinds.json` file, the config takes the form of an array of json objects, with the following keys:
 
     key             the key to bind the command to - same syntax as input.conf
     command         a json array of commands and arguments

--- a/README.md
+++ b/README.md
@@ -45,6 +45,69 @@ It is highly recommended that this be customised for the computer being used; [f
 ## Multi-Select
 By default file-browser only opens/appends the single item that the cursor has selected. However, using the `Ctrl` keybinds specified above, it is possible to select multiple items to open all at once. Selected items are shown in a different colour to the cursor. When multiple items are selected, they will be appended after the currently selected file when using the ENTER commands. The currently selected (with the cursor) file will always be added first, regardless of if it is part of the multi-selection, and will follow replace/append behaviour as normal. Selected items will be appended to the playlist afterwards in the order that they appear on the screen.
 
+## Custom Keybinds
+File-browser also supports custom keybinds. These keybinds send normal input commands, but the script will substitute characters in the command strings for specific values depending on the currently open directory, and currently selected item.
+This allows for a wide range of customised behaviour, such as loading subtitle files from the browser, or copying the path of the selected item to the clipboard.
+
+The keybinds are declared in the `~~/script-opts/file-browser-keybinds.json` file, the config takes the form of an array of json objects, with the following keys:
+
+    key             the key to bind the command to - same syntax as input.conf
+    command         a json array of commands and arguments
+    filter          optional - run the command on just a file or folder
+    multiselect     optional - command is run on all commands selected (default true)
+
+Example:
+```
+{
+    "key": "KP1",
+    "command": ["print-text", "example"],
+    "filter": "file"
+}
+```
+
+The command can also be an array of arrays, in order to send multiple commands at once:
+```
+    {
+        "key": "KP2",
+        "command": [
+            ["command": ["print-text", "example2"],
+            "command": ["show-text", "example2"]
+        ],
+        "multiselect": false
+    }
+```
+
+Filter should not be included unless one wants to limit what types of list entries the command should be run on.
+To only run the command for directories use `dir`, to only run the command for files use `file`.
+
+The script will scan every string in the command for the special substitution strings, they are:
+
+    %f      filepath of the selected item
+    %n      name of the selected item (what appears on the list)
+    %p      currently open directory
+    %d      name of the current directory (characters between the last two '/')
+    %%      escape the previous codes
+
+Additionally, using the uppercase forms of those codes will send the substituted string through the `string.format("%q", str)` function.
+This adds double quotes around the string and automatically escapes any quotation marks within the string.
+This is not necessary for most mpv commands, but can be very useful when sending commands to the console with the `run` command.
+
+Example of a command to add a subtitle file:
+
+```
+    {
+        "key": "Alt+ENTER",
+        "command": ["sub-add", "%f"],
+        "filter": "file"
+    }
+```
+
+When multiple items are selected the command will be run on every item in the order they appear on the screen.
+This can be controlled by the `multiselect` flag, which takes a boolean value.
+When not set the flag defaults to `true`.
+
+Examples can be found [here](/file-browser-keybinds.json).
+
 ## Add-ons
 Add-ons are extra scripts that add parsing support for non-native filesystems.
 They can be enabled by loading the add-on script normally and enabling the corresponding `script-opt`.

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Example:
 
 The command can also be an array of arrays, in order to send multiple commands at once:
 ```
-    {
-        "key": "KP2",
-        "command": [
-            ["command": ["print-text", "example2"],
-            "command": ["show-text", "example2"]
-        ],
-        "multiselect": false
-    }
+{
+    "key": "KP2",
+    "command": [
+        ["command": ["print-text", "example2"],
+        "command": ["show-text", "example2"]
+    ],
+    "multiselect": false
+}
 ```
 
 Filter should not be included unless one wants to limit what types of list entries the command should be run on.
@@ -95,11 +95,11 @@ This is not necessary for most mpv commands, but can be very useful when sending
 Example of a command to add a subtitle file:
 
 ```
-    {
-        "key": "Alt+ENTER",
-        "command": ["sub-add", "%f"],
-        "filter": "file"
-    }
+{
+    "key": "Alt+ENTER",
+    "command": ["sub-add", "%f"],
+    "filter": "file"
+}
 ```
 
 When multiple items are selected the command will be run on every item in the order they appear on the screen.

--- a/README.md
+++ b/README.md
@@ -71,8 +71,8 @@ The command can also be an array of arrays, in order to send multiple commands a
 {
     "key": "KP2",
     "command": [
-        ["command": ["print-text", "example2"],
-        "command": ["show-text", "example2"]
+        ["print-text", "example2"],
+        ["show-text", "example2"]
     ],
     "multiselect": false
 }

--- a/file-browser-keybinds.json
+++ b/file-browser-keybinds.json
@@ -1,0 +1,52 @@
+[
+    {
+        "key": "KP1",
+        "command": ["print-text", "file: %f"]
+    },
+    {
+        "key": "KP2",
+        "command": ["print-text", "filename: %F"]
+    },
+    {
+        "key": "KP3",
+        "command": ["print-text", "directory: %d"]
+    },
+    {
+        "key": "KP4",
+        "command": ["print-text", "directory name: %D"]
+    },
+    {
+        "key": "KP5",
+        "command": ["print-text", "escape the code: %%f"]
+    },
+    {
+        "key": "KP6",
+        "command": ["print-text", "full filepath via concatenation: %d%F"]
+    },
+    {
+        "key": "Alt+ENTER",
+        "command": ["sub-add", "%f"],
+        "filter": "file"
+    },
+    {
+        "key": "Alt+DEL",
+        "command": ["run", "rm", "\"%f\""],
+        "filter": "file"
+    },
+    {
+        "key": "Ctrl+c",
+        "command": [
+            ["run", "powershell", "-command", "Set-Clipboard", "\"%f\""],
+            ["print-text", "copied filepath to clipboard"]
+        ]
+    },
+    {
+        "key": "Ctrl+o",
+        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%d\" ).TrimEnd('/') -replace '/', '\\' )"]
+    },
+    {
+        "key": "Ctrl+O",
+        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%f\" ).TrimEnd('/') -replace '/', '\\' )"],
+        "filter": "dir"
+    }
+]

--- a/file-browser-keybinds.json
+++ b/file-browser-keybinds.json
@@ -46,12 +46,12 @@
     },
     {
         "key": "Ctrl+o",
-        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%d\" ).TrimEnd('/') -replace '/', '\\' )"],
+        "command": ["run", "powershell", "-command", "explorer.exe", "(( %P ).TrimEnd('/') -replace '/', '\\' )"],
         "multiselect": false
     },
     {
         "key": "Ctrl+O",
-        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%f\" ).TrimEnd('/') -replace '/', '\\' )"],
+        "command": ["run", "powershell", "-command", "explorer.exe", "(( %F ).TrimEnd('/') -replace '/', '\\' )"],
         "filter": "dir",
         "multiselect": true
     }

--- a/file-browser-keybinds.json
+++ b/file-browser-keybinds.json
@@ -5,15 +5,15 @@
     },
     {
         "key": "KP2",
-        "command": ["print-text", "filename: %F"]
+        "command": ["print-text", "name: %n"]
     },
     {
         "key": "KP3",
-        "command": ["print-text", "directory: %d"]
+        "command": ["print-text", "open directory: %p"]
     },
     {
         "key": "KP4",
-        "command": ["print-text", "directory name: %D"]
+        "command": ["print-text", "directory name: %d"]
     },
     {
         "key": "KP5",
@@ -24,19 +24,23 @@
         "command": ["print-text", "full filepath via concatenation: %d%F"]
     },
     {
+        "key": "KP7",
+        "command": ["print-text", "quote/escape filepath: %F"]
+    },
+    {
         "key": "Alt+ENTER",
         "command": ["sub-add", "%f"],
         "filter": "file"
     },
     {
         "key": "Alt+DEL",
-        "command": ["run", "rm", "\"%f\""],
+        "command": ["run", "rm", "%F"],
         "filter": "file"
     },
     {
         "key": "Ctrl+c",
         "command": [
-            ["run", "powershell", "-command", "Set-Clipboard", "\"%f\""],
+            ["run", "powershell", "-command", "Set-Clipboard", "%F"],
             ["print-text", "copied filepath to clipboard"]
         ]
     },

--- a/file-browser-keybinds.json
+++ b/file-browser-keybinds.json
@@ -46,11 +46,13 @@
     },
     {
         "key": "Ctrl+o",
-        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%d\" ).TrimEnd('/') -replace '/', '\\' )"]
+        "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%d\" ).TrimEnd('/') -replace '/', '\\' )"],
+        "multiselect": false
     },
     {
         "key": "Ctrl+O",
         "command": ["run", "powershell", "-command", "explorer.exe", "(( \"%f\" ).TrimEnd('/') -replace '/', '\\' )"],
-        "filter": "dir"
+        "filter": "dir",
+        "multiselect": true
     }
 ]

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -594,7 +594,7 @@ local function custom_command(cmd)
     end
 
     --runs the command on all multi-selected items
-    if next(state.selection) then
+    if cmd.multiselect and next(state.selection) then
         local selection = sort_keys(state.selection)
         for i = 1, #selection do
             run_custom_command(cmd.command, selection[i])
@@ -642,6 +642,7 @@ if o.custom_keybinds then
         if not json then error("invalid json syntax for "..path) end
 
         for i = 1, #json do
+            if json[i].multiselect == nil then json[i].multiselect = true end
             table.insert(list.keybinds, { json[i].key, "custom"..tostring(i), function() custom_command(json[i]) end, {} })
         end
     end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -557,9 +557,13 @@ local function format_command_table(t, index)
         copy[i] = t[i]:gsub("%%.", {
             ["%%"] = "%",
             ["%f"] = l[index] and state.directory..l[index].name or "",
-            ["%F"] = l[index] and (l[index].label or l[index].name) or "",
-            ["%d"] = state.directory or "",
-            ["%D"] = get_dir_name() or ""
+            ["%F"] = string.format("%q", l[index] and state.directory..l[index].name or ""),
+            ["%n"] = l[index] and (l[index].label or l[index].name) or "",
+            ["%N"] = string.format("%q", l[index] and (l[index].label or l[index].name) or ""),
+            ["%p"] = state.directory or "",
+            ["%P"] = string.format("%q", state.directory or ""),
+            ["%d"] = get_dir_name() or "",
+            ["%D"] = string.format("q", get_dir_name() or "")
         })
     end
     return copy
@@ -573,8 +577,8 @@ local function run_custom_command(t, index)
             run_custom_command(t[i], index)
         end
     else
-        msg.debug("running command: " .. utils.to_string(t))
         local custom_cmd = format_command_table(t, index)
+        msg.debug("running command: " .. utils.to_string(custom_cmd))
         mp.command_native(custom_cmd)
     end
 end

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -24,6 +24,10 @@ num_entries=20
 #only show files compatible with mpv in the browser
 filter_files=yes
 
+#enable custom keybinds
+#the keybind json file must go in ~~/script-opts
+custom_keybinds=no
+
 #file-browser only shows files that are compatible with mpv by default
 #adding a file extension to this list will add it to the extension whitelist
 #extensions are separated with the root seperators, do not use any spaces


### PR DESCRIPTION
Add ability for users to specify custom keybinds to run.

The script scans for specific string codes and substitutes
them with information about the current directory or
selection.