### PR TITLE
Load subs into video when opened

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The following keybinds are only set while the browser is open:
     Ctrl+DOWN       drag selection down
     Ctrl+UP         drag selection up
 
+When attempting to play or append a subtitle file the script will instead load the subtitle track into the existing video.
+
 ## Root Directory
 To accomodate for both windows and linux this script has its own virtual root directory where drives and file folders can be manually added. This can also be used to save favourite directories. The root directory can only contain folders.
 
@@ -47,7 +49,7 @@ By default file-browser only opens/appends the single item that the cursor has s
 
 ## Custom Keybinds
 File-browser also supports custom keybinds. These keybinds send normal input commands, but the script will substitute characters in the command strings for specific values depending on the currently open directory, and currently selected item.
-This allows for a wide range of customised behaviour, such as loading subtitle files from the browser, or copying the path of the selected item to the clipboard.
+This allows for a wide range of customised behaviour, such as loading additional audio tracks from the browser, or copying the path of the selected item to the clipboard.
 
 The feature is disabled by default, but is enabled with the `custom_keybinds` script-opt.
 Keybinds are declared in the `~~/script-opts/file-browser-keybinds.json` file, the config takes the form of an array of json objects, with the following keys:
@@ -93,12 +95,12 @@ Additionally, using the uppercase forms of those codes will send the substituted
 This adds double quotes around the string and automatically escapes any quotation marks within the string.
 This is not necessary for most mpv commands, but can be very useful when sending commands to the console with the `run` command.
 
-Example of a command to add a subtitle file:
+Example of a command to add an audio track:
 
 ```
 {
     "key": "Alt+ENTER",
-    "command": ["sub-add", "%f"],
+    "command": ["audio-add", "%f"],
     "filter": "file"
 }
 ```

--- a/file-browser-keybinds.json
+++ b/file-browser-keybinds.json
@@ -28,11 +28,6 @@
         "command": ["print-text", "quote/escape filepath: %F"]
     },
     {
-        "key": "Alt+ENTER",
-        "command": ["sub-add", "%f"],
-        "filter": "file"
-    },
-    {
         "key": "Alt+DEL",
         "command": ["run", "rm", "%F"],
         "filter": "file"

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -67,7 +67,7 @@ list.header_style = o.ass_header
 
 local cache = {}
 local extensions = nil
-local sub_extensions = nil
+local sub_extensions = {}
 local state = {
     directory = nil,
     selection = {},
@@ -184,12 +184,12 @@ local function sort(t)
     return t
 end
 
---checks if the name has a valid extension
-local function is_valid(name)
+--checks returns the extension of the file
+local function get_extension(name)
     local index = name:find([[.[^.]*$]])
     if not index then return false end
     local fileext = name:sub(index + 1)
-    return extensions[fileext]
+    return fileext
 end
 
 --removes items and folders from the list
@@ -201,7 +201,7 @@ local function filter(t)
         local temp = t[i]
         t[i] = nil
         if  ( temp.type == "dir" and (not o.filter_dot_dirs or (temp.name:find('%.') ~= 1)) )
-            or ( temp.type == "file" and (not o.filter_files or is_valid(temp.name)) )
+            or ( temp.type == "file" and (not o.filter_files or extensions[ get_extension(temp.name) ]) )
         then
             t[top] = temp
             top = top+1
@@ -318,7 +318,7 @@ local function update_local_list()
 
         --only adds whitelisted files to the browser
         if o.filter_files then
-            if not is_valid(item) then goto continue end
+            if not extensions[ get_extension(item) ] then goto continue end
         end
 
         msg.debug(item)
@@ -481,7 +481,9 @@ local function loadfile(item, flags)
     local path = state.directory..item.name
     if (path == state.dvd_device) then path = "dvd://"
     elseif item.type == "dir" then return loadlist(item, path, flags) end
-    return mp.commandv('loadfile', path, flags)
+
+    if sub_extensions[ get_extension(item.name) ] then mp.commandv("sub-add", path, flags == "replace" and "select" or "auto")
+    else mp.commandv('loadfile', path, flags) end
 end
 
 --opens the selelected file(s)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -67,6 +67,7 @@ list.header_style = o.ass_header
 
 local cache = {}
 local extensions = nil
+local sub_extensions = nil
 local state = {
     directory = nil,
     selection = {},
@@ -92,6 +93,14 @@ local compatible_file_extensions = {
     "tif","tiff","tod","trp","truehd","true-hd","ts","tsa","tsv","tta","tts","vfw","vgm","vgz","vob","vro","wav","weba","webm","webp","wm","wma","wmv","wtv",
     "wv","x264","x265","xvid","y4m","yuv"
 }
+
+--creating a set of subtitle extensions for custom subtitle loading behaviour
+local subtitle_extensions = {
+    "etf","etf8","utf-8","idx","sub","srt","rt","ssa","ass","mks","vtt","sup","scc","smi","lrc",'pgs'
+}
+for i = 1, #subtitle_extensions do
+    sub_extensions[subtitle_extensions[i]] = true
+end
 
 --detects whether or not to highlight the given entry as being played
 local function highlight_entry(v)
@@ -145,6 +154,9 @@ local function setup_extensions_list()
     --adding file extensions to the set
     for i=1, #compatible_file_extensions do
         extensions[compatible_file_extensions[i]] = true
+    end
+    for i = 1, #subtitle_extensions do
+        extensions[subtitle_extensions[i]] = true
     end
 
     --adding extra extensions on the whitelist


### PR DESCRIPTION
This adds native support for loading subtitles into the player.

Whenever a user tries to open a subtitle file the script will
automatically load the subtitle track instead of trying to
load the subtitle file on its own.