### PR TITLE
Support default MacOS configuration

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -52,6 +52,10 @@ local o = {
     --when enabled the keybind disables autoload for the file
     autoload = false,
 
+    --allows custom icons be set to fix incompatabilities with some fonts
+    folder_icon = "🖿",
+    cursor_icon = "➤",
+
     --enable addons
     dvd_browser = false,
     http_browser = false,
@@ -183,7 +187,7 @@ function list:format_line(i, v)
     self:append(o.ass_body)
 
     --handles custom styles for different entries
-    if i == list.selected then self:append(list.cursor_style..[[➤\h]]..o.ass_body)
+    if i == list.selected then self:append(list.cursor_style..o.cursor_icon.."\\h"..o.ass_body)
     else self:append([[\h\h\h\h]]) end
 
     --sets the selection colour scheme
@@ -196,7 +200,7 @@ function list:format_line(i, v)
     elseif playing_file then self:append(o.ass_playing) end
 
     --sets the folder icon
-    if v.type == 'dir' then self:append([[🖿\h]]) end
+    if v.type == 'dir' then self:append(o.folder_icon.."\\h") end
 
     --adds the actual name of the item
     self:append(v.ass or v.label or v.name)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -207,9 +207,13 @@ function list:format_line(i, v)
     if v.type == 'dir' then self:append(o.folder_icon.."\\h") end
 
     --adds the actual name of the item
+    self:append("{\\fn"..list.font.."}")
     self:append(v.ass or v.label or v.name)
     self:newline()
 end
+
+--track the osd-font property without needing to grab it every list update
+mp.observe_property("osd-font", "string", function(_,font) list.font = font end)
 
 --updates the header with the current directory
 function list:format_header()
@@ -287,7 +291,7 @@ local function filter(t)
         local temp = t[i]
         t[i] = nil
 
-        if  ( temp.type == "dir" and not ( o.filter_dot_dirs and temp.name:sub(1,1) == ".") ) or
+        if  ( temp.type == "dir"    and not ( o.filter_dot_dirs and temp.name:sub(1,1) == ".") ) or
             ( temp.type == "file"   and not ( o.filter_dot_files and (temp.name:sub(1,1) == ".") )
                                     and not ( o.filter_files and not extensions[ get_extension(temp.name) ] ) )
         then
@@ -405,8 +409,8 @@ local function scan_directory(directory)
         local item = list2[i]
 
         --only adds whitelisted files to the browser
-        if  not ( o.filter_files and not extensions[ get_extension(item) ] )
-            and not (o.filter_dot_files and item:sub(1,1) == ".")
+        if  not ( o.filter_files and not extensions[ get_extension(item) ] ) and
+            not (o.filter_dot_files and item:sub(1,1) == ".")
         then
             msg.debug(item)
             table.insert(new_list, {name = item, ass = list.ass_escape(item), type = 'file'})

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -279,17 +279,13 @@ local function filter(t)
         local temp = t[i]
         t[i] = nil
 
-        if temp.type == "dir" and (o.filter_dot_dirs and temp.name:sub(1,1) == ".") then goto continue end
-
-        if temp.type == "file"  then
-            if o.filter_dot_files and (temp.name:sub(1,1) == ".") then goto continue end
-            if o.filter_files and not extensions[ get_extension(temp.name) ] then goto continue end
+        if  ( temp.type == "dir" and not ( o.filter_dot_dirs and temp.name:sub(1,1) == ".") ) or
+            ( temp.type == "file"   and not ( o.filter_dot_files and (temp.name:sub(1,1) == ".") )
+                                    and not ( o.filter_files and not extensions[ get_extension(temp.name) ] ) )
+        then
+            t[top] = temp
+            top = top+1
         end
-
-        t[top] = temp
-        top = top+1
-
-        ::continue::
     end
 end
 
@@ -389,12 +385,10 @@ local function scan_directory(directory)
         local item = list1[i]
 
         --filters hidden dot directories for linux
-        if o.filter_dot_dirs and item:sub(1,1) == "." then goto continue end
-
-        msg.debug(item..'/')
-        table.insert(new_list, {name = item..'/', ass = list.ass_escape(item..'/'), type = 'dir'})
-
-        ::continue::
+        if not (o.filter_dot_dirs and item:sub(1,1) == ".") then
+            msg.debug(item..'/')
+            table.insert(new_list, {name = item..'/', ass = list.ass_escape(item..'/'), type = 'dir'})
+        end
     end
 
     --appends files to the list of directory items
@@ -403,16 +397,12 @@ local function scan_directory(directory)
         local item = list2[i]
 
         --only adds whitelisted files to the browser
-        if o.filter_files then
-            if not extensions[ get_extension(item) ] then goto continue end
+        if  not ( o.filter_files and not extensions[ get_extension(item) ] )
+            and not (o.filter_dot_files and item:sub(1,1) == ".")
+        then
+            msg.debug(item)
+            table.insert(new_list, {name = item, ass = list.ass_escape(item), type = 'file'})
         end
-
-        if o.filter_dot_files and item:sub(1,1) == "." then goto continue end
-
-        msg.debug(item)
-        table.insert(new_list, {name = item, ass = list.ass_escape(item), type = 'file'})
-
-        ::continue::
     end
     sort(new_list)
     return new_list

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -860,7 +860,7 @@ end)
 
 --updates the dvd_device
 mp.observe_property('dvd-device', 'string', function(_, device)
-    if device == "" then device = "/dev/dvd/" end
+    if not device or device == "" then device = "/dev/dvd/" end
     list.dvd_device = fix_path(device, true)
 end)
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -53,8 +53,10 @@ local o = {
     autoload = false,
 
     --allows custom icons be set to fix incompatabilities with some fonts
+    --the `\h` character is a hard space to add padding between the symbol and the text
     folder_icon = "🖿",
     cursor_icon = "➤",
+    indent_icon = [[\h\h\h]],
 
     --enable addons
     dvd_browser = false,
@@ -81,6 +83,8 @@ local list = require "scroll-list"
 list.num_entries = o.num_entries
 list.header_style = o.ass_header
 list.cursor_style = o.ass_cursor
+list.cursor = o.cursor_icon
+list.indent = o.indent_icon
 
 list.directory = nil
 list.directory_label = nil
@@ -187,8 +191,8 @@ function list:format_line(i, v)
     self:append(o.ass_body)
 
     --handles custom styles for different entries
-    if i == list.selected then self:append(list.cursor_style..o.cursor_icon.."\\h"..o.ass_body)
-    else self:append([[\h\h\h\h]]) end
+    if i == list.selected then self:append(list.cursor_style..list.cursor.."\\h"..o.ass_body)
+    else self:append(list.indent.."\\h") end
 
     --sets the selection colour scheme
     local multiselected = list.selection[i]

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -55,6 +55,9 @@ autoload=no
 
 #allows custom icons be set to fix incompatabilities with some fonts
 #the `\h` character is a hard space to add padding
+#the ass tag `{\fnName}` can be used to modify the font to one supporting the icon
+#for example setting {\fnsymbola}🖿 will change the font for the folder icon
+#changing cursor or indent fonts will propagate to the folder icon, but none will effect text
 folder_icon=🖿
 cursor_icon=➤
 indent_icon=\h\h\h

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -53,6 +53,10 @@ custom_dir_loading=no
 #when enabled the keybind disables autoload for the file
 autoload=no
 
+#allows custom icons be set to fix incompatabilities with some fonts
+folder_icon=🖿
+cursor_icon=➤
+
 #enables addons
 http_browser=no
 ftp_browser=no

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -54,8 +54,10 @@ custom_dir_loading=no
 autoload=no
 
 #allows custom icons be set to fix incompatabilities with some fonts
+#the `\h` character is a hard space to add padding
 folder_icon=🖿
 cursor_icon=➤
+indent_icon=\h\h\h
 
 #enables addons
 http_browser=no


### PR DESCRIPTION
This includes:
-  removing lua 5.2 code (goto statements) 
- adding fail-safe for observe functions returning nil instead of an empty string
- adding ability to customise icons to support incomplete fonts

Fixes #18