### PR TITLE
Remove dependency on mpv-scroll-list

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ This script allows users to browse and open files and folders entirely from with
 
 By default only file types compatible with mpv will be shown, but this can be changed in the config file.
 
-This script requires [mpv-scroll-list](https://github.com/CogentRedTester/mpv-scroll-list) to work, simply place `scroll-list.lua` into the `~~/scripts` folder.
-
 ## Keybinds
 The following keybind is set by default
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -903,7 +903,7 @@ local function open_file(flags, autoload)
         end
 
         --reset the selection after
-        selection = {}
+        state.selection = {}
         disable_select_mode()
         update_ass()
 


### PR DESCRIPTION
Scroll list has worked amazingly for some of my other scripts,
but file-browser had already been designed around its own
list implementation. This meant that huge chunks of scroll list
were being replaced by custom parsing functions, which made
understanding the flow of the code extremely difficult.

Requiring scroll-list also goes against the original goal of the script,
which was to be a universal file browser with no external dependencies.

The plan now is to combine the custom functions in file-browser with
the generic functions inside scroll-list. This should minimise the
number of problems with switching over to the new system.
There have been too many changes to just roll back the original
scroll-list implementation.