### PR TITLE
Addon System Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,10 +167,13 @@ See [here](/file-browser-keybinds.json).
 
 ## Add-ons
 Add-ons are extra scripts that add parsing support for non-native filesystems.
-They can be enabled by loading the add-on script normally and enabling the corresponding `script-opt`.
+They can be enabled by setting `addon` script-opt to yes, and placing the addon file into the `~~/script-modules/file-browser-addons/` directory.
 
 Browsing filesystems provided by add-ons should feel identical to the normal handling of the script,
 but they may require extra commandline tools be installed.
+
+Since addons are loaded programatically from the addon directory it is possible for anyone to write their own addon to parse custom directory structures.
+Instructions on how to do this are available [here](addons/README.md).
 
 ### [http-browser](addons/http-browser.lua)
 This add-on implements support for http/https file servers, specifically the directory indexes that apache servers dynamically generate.
@@ -188,8 +191,7 @@ When playing a dvd, or when moving into the `--dvd-device` directory, the add-on
 This add-on is a little different from the others; dvd-browser is actually standalone, and has a number of other dvd related features that don't
 require the browser at all to make DVD playback more enjoyable, such as automatic playlist management.
 
-It also has it's own, more limitted, browser, but overwriting the default keybind to open file-browser instead effectively disables it.
-Both scripts use `MENU` as the default toggle command, so it will be necessary to explicitly specify which to use by putting `MENU script-binding browse-files` in input.conf.
+It also has it's own, more limitted, browser, but it is automatically disabled when the script detects it is being loaded as an addon for file-browser.
 
 Note that `lsdvd` is only available on linux, but the script has special support for WSL on windows 10.
 

--- a/addons/README.md
+++ b/addons/README.md
@@ -14,14 +14,15 @@ File-browser automatically loads any lua files from the `~~/script-modules/file-
 |-----------|--------|-----------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
 | priority  | number | -         | -                                | a number to determine what order parsers are tested - 50 is a recommended neutral value                                     |
 | can_parse | method | string    | boolean                          | returns whether or not the given path is compatible with the parser                                                         |
-| parse     | method | string    | list_table, [ boolean, boolean ] | returns an array of item_tables, and bools representing whether the list has already been sorted and filtered, respectively |
+| parse     | method | string    | list_table, boolean, boolean     | returns an array of item_tables, and bools representing whether the list has already been filtered and sorted, respectively |
 
 When a directory is loaded file-browser will iterate through the list of parsers from lowest to highest priority.
 The first parser for which `can_parse` returns true will be selected as the parser for that directory.
 
 The `parse` method will then be called on the selected parser, which is expected to return either a table of list items, or nil.
-If nil is returned, then browser will move to the root, otherwise if an empty table is returned the browser will treat the directory as empty.
-Additionally, parse can return two additional values after the list; these values will be evaluated into booleans, and will be used to determine if the output of the parser requires additional filtering and sorting, respectively.
+If nil is returned, then the browser will move to the root, otherwise if an empty table is returned the browser will treat the directory as empty.
+
+Additionally, parse can return two values after the list; these values will be evaluated into booleans, and will be used to determine if the output of the parser requires additional filtering and sorting, respectively.
 This can be useful if you choose to filter or sort the script yourself, or if the directory does not conform to standard filesystem rules (such as dvd-browser).
 Otherwise, the two extra return values can be excluded and file-browser will automatically filter and sort everything according to user preferences.
 
@@ -38,9 +39,9 @@ Each item has the following members:
 | ass   | string | no       | a string to print to the screen without escaping ass styling - overrides label and name   |
 | path  | string | no       | opening the item uses this full path instead of appending directory and name              |
 
-The script expects that `type` and `name` will be set for each item, so leaving these out will probably crash the script.
-The script also assumes that all directories end in a `/` when appending name.
-The API function `fix_path` (see next section) will ensure that the correct characters are used for paths.
+File-browser expects that `type` and `name` will be set for each item, so leaving these out will probably crash the script.
+File-browser also assumes that all directories end in a `/` when appending name, and that there will be no backslashes.
+The API function `fix_path` (see next section) can be used to ensure that paths conform to file-browser rules.
 
 ## API Functions
 
@@ -57,7 +58,7 @@ These functions are only made available once file-browser has fully imported the
 | fix_path      | function | string, boolean  | string                  | takes a path and an is_directory boolean and returns a corrected path                                                                                  |
 | ass_escape    | function | string           | string                  | returns the string with escaped ass styling codes                                                                                                      |
 | get_extension | function | string           | string                  | returns the file extension of the given file                                                                                                           |
-| valid_file    | function | string           | boolean                 | tests if the given filename passes the user set filters (valid extensions and dot files))                                                              |
+| valid_file    | function | string           | boolean                 | tests if the given filename passes the user set filters (valid extensions and dot files)                                                               |
 | valid_dir     | function | string           | boolean                 | tests if the given directory name passes the user set filters (dot directories)                                                                        |
 | filter        | function | list_table       | list_table              | iterates through the given list and removes items that don't pass the filters - acts directly on the given list, it does not create a copy             |
 | sort          | function | list_table       | list_table              | iterates through the given list and sorts the items using file-browsers sorting algorithm - acts directly on the given list, it does not create a copy |
@@ -75,4 +76,4 @@ All tables returned by these functions are copies to ensure addons can't break t
 | get_sub_extensions  | function | -         | table   | like above but with subtitle extensions - note that subtitles show up in the above list as well                       |
 | get_parsers         | function | -         | table   | an array of the loaded parsers                                                                                        |
 | get_dvd_device      | function | -         | string  | the current dvd-device - formatted to work with file-browser                                                          |
-| get_state           | function |           | table   | the current state values of the browser - this is probably useless                                                    |
+| get_state           | function | -         | table   | the current state values of the browser - this is probably useless                                                    |

--- a/addons/README.md
+++ b/addons/README.md
@@ -1,0 +1,1 @@
+# How to Write an Addon

--- a/addons/README.md
+++ b/addons/README.md
@@ -1,1 +1,78 @@
 # How to Write an Addon
+
+Addons provide ways for file-browser to parse non-native directory structures. This document describes how one can create their own custom addon. For examples see [ftp-browser](ftp-browser.lua) and [http-browser](http-browser.lua).
+
+#### Terminology
+For the purpose of this document addons refer to the scripts being loaded while parsers are the objects the scripts return. However, these terms are practically synonymous.
+Additionally, `method` refer to functions called using the `object:funct()` syntax, and hence have access to the self object, whereas `function` is the standard `object.funct()` syntax.
+
+## Overview
+
+File-browser automatically loads any lua files from the `~~/script-modules/file-browser-addons` directory as modules. Each addon must return an object with the following three members:
+
+| key       | type   | arguments | returns                          | description                                                                                                                 |
+|-----------|--------|-----------|----------------------------------|-----------------------------------------------------------------------------------------------------------------------------|
+| priority  | number | -         | -                                | a number to determine what order parsers are tested - 50 is a recommended neutral value                                     |
+| can_parse | method | string    | boolean                          | returns whether or not the given path is compatible with the parser                                                         |
+| parse     | method | string    | list_table, [ boolean, boolean ] | returns an array of item_tables, and bools representing whether the list has already been sorted and filtered, respectively |
+
+When a directory is loaded file-browser will iterate through the list of parsers from lowest to highest priority.
+The first parser for which `can_parse` returns true will be selected as the parser for that directory.
+
+The `parse` method will then be called on the selected parser, which is expected to return either a table of list items, or nil.
+If nil is returned, then browser will move to the root, otherwise if an empty table is returned the browser will treat the directory as empty.
+Additionally, parse can return two additional values after the list; these values will be evaluated into booleans, and will be used to determine if the output of the parser requires additional filtering and sorting, respectively.
+This can be useful if you choose to filter or sort the script yourself, or if the directory does not conform to standard filesystem rules (such as dvd-browser).
+Otherwise, the two extra return values can be excluded and file-browser will automatically filter and sort everything according to user preferences.
+
+## The List Array
+
+The list array must be made up of item_tables, which contain details about each item in the directory.
+Each item has the following members:
+
+| key   | type   | required | description                                                                               |
+|-------|--------|----------|-------------------------------------------------------------------------------------------|
+| name  | string | yes      | name of the item, and the string to append after the directory when opening a file/folder |
+| type  | string | yes      | determines whether the item is a file ("file") or directory ("dir")                       |
+| label | string | no       | an alternative string to print to the screen instead of name                              |
+| ass   | string | no       | a string to print to the screen without escaping ass styling - overrides label and name   |
+| path  | string | no       | opening the item uses this full path instead of appending directory and name              |
+
+The script expects that `type` and `name` will be set for each item, so leaving these out will probably crash the script.
+The script also assumes that all directories end in a `/` when appending name.
+The API function `fix_path` (see next section) will ensure that the correct characters are used for paths.
+
+## API Functions
+
+All parsers are provided with a range of API functions to make addons more powerful.
+These functions are added to the parser after being loaded via a metatable, so can be called through the self argument or the parser object.
+These functions are only made available once file-browser has fully imported the parsers, so if a script wants to call them immediately on load they must do so in the `setup` method.
+
+### Utility Functions
+
+| key           | type     | arguments        | returns                 | description                                                                                                                                            |
+|---------------|----------|------------------|-------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
+| setup         | method   | -                | -                       | a function that is automatically run once the parsers have been imported - this function is not set by default, and must instead be created by addons. |
+| defer         | method   | string           | table, boolean, boolean | runs parse(string) on the next valid parser - this allows addons to give up on a directory and let another parser try                                  |
+| fix_path      | function | string, boolean  | string                  | takes a path and an is_directory boolean and returns a corrected path                                                                                  |
+| ass_escape    | function | string           | string                  | returns the string with escaped ass styling codes                                                                                                      |
+| get_extension | function | string           | string                  | returns the file extension of the given file                                                                                                           |
+| valid_file    | function | string           | boolean                 | tests if the given filename passes the user set filters (valid extensions and dot files))                                                              |
+| valid_dir     | function | string           | boolean                 | tests if the given directory name passes the user set filters (dot directories)                                                                        |
+| filter        | function | list_table       | list_table              | iterates through the given list and removes items that don't pass the filters - acts directly on the given list, it does not create a copy             |
+| sort          | function | list_table       | list_table              | iterates through the given list and sorts the items using file-browsers sorting algorithm - acts directly on the given list, it does not create a copy |
+
+### Getters and Setters
+These functions allow addons to safely get information from file-browser, as well as set some useful values.
+All tables returned by these functions are copies to ensure addons can't break things.
+
+| key                 | type     | arguments | returns | description                                                                                                           |
+|---------------------|----------|-----------|---------|-----------------------------------------------------------------------------------------------------------------------|
+| set_directory_label | function | string    | -       | set an alternative directory string to print to the header - useful to replace encoded paths                          |
+| set_empty_text      | function | string    | -       | set alternative text to display when directory is empty - can also be used for error messages                         |
+| get_script_opts     | function | -         | table   | the table of script opts set by the user - this never gets changed during runtime                                     |
+| get_extensions      | function | -         | table   | a set of valid extensions after applying the user's whitelist/blacklist - in the form {ext1 = true, ext2 = true, ...} |
+| get_sub_extensions  | function | -         | table   | like above but with subtitle extensions - note that subtitles show up in the above list as well                       |
+| get_parsers         | function | -         | table   | an array of the loaded parsers                                                                                        |
+| get_dvd_device      | function | -         | string  | the current dvd-device - formatted to work with file-browser                                                          |
+| get_state           | function |           | table   | the current state values of the browser - this is probably useless                                                    |

--- a/addons/http-browser.lua
+++ b/addons/http-browser.lua
@@ -4,7 +4,6 @@
 
 local mp = require 'mp'
 local msg = require 'mp.msg'
-local utils = require 'mp.utils'
 
 --decodes a URL address
 --this piece of code was taken from: https://stackoverflow.com/questions/20405985/lua-decodeuri-luvit/20406960#20406960
@@ -19,7 +18,15 @@ do
     end
 end
 
-local function parse_http(directory)
+local http = {
+    priority = 70
+}
+
+function http:can_parse(name)
+    return name:find("^https?://")
+end
+
+function http:parse(directory)
     msg.verbose(directory)
     msg.trace("curl -k -l -m 5 "..string.format("%q", directory))
 
@@ -47,51 +54,27 @@ local function parse_http(directory)
     html = html.stdout
     local list = {}
     for str in string.gmatch(html, "[^\r\n]+") do
-        if str:sub(1,4) ~= "<tr>" then goto continue end
+        local valid = true
+        if str:sub(1,4) ~= "<tr>" then valid = false end
 
         local link = str:match('href="(.-)"')
         local alt = str:match('alt="%[(.-)%]"')
 
-        if not alt or not link then goto continue end
-        if alt == "PARENTDIR" or alt == "ICO" then goto continue end
-        if link:find("[:?<>|]") then goto continue end
+        if valid and not alt or not link then valid = false end
+        if valid and alt == "PARENTDIR" or alt == "ICO" then valid = false end
+        if valid and link:find("[:?<>|]") then valid = false end
 
-        msg.trace(alt..": "..link)
-        table.insert(list, { name = link, type = (alt == "DIR" and "dir" or "file"), label = decodeURI(link) })
+        local is_dir = (alt == "DIR")
+        if valid and is_dir and not self.valid_dir(link) then valid = false
+        elseif valid and self.valid_file(link) then valid = false end
 
-        ::continue::
-    end
-
-    return list
-end
-
-local flag = ""
-
---recursively opens the given directory
-local function open_directory(path)
-    local list = parse_http(path)
-    if not list then return end
-    for i = 1, #list do
-        local item_path = path..list[i].name
-
-        if list[i].type == "dir" then open_directory(item_path)
-        else
-            mp.commandv("loadfile", item_path, flag)
-            flag = "append"
+        if valid then
+            msg.trace(alt..": "..link)
+            table.insert(list, { name = link, type = (is_dir and "dir" or "file"), label = decodeURI(link) })
         end
     end
+
+    return self.sort(list)
 end
 
---custom parsing of directories
-mp.register_script_message("http/browse-dir", function(dir, callback, ...)
-    local response = {}
-    response.list, response.empty_text = parse_http(dir)
-    response.directory_label = decodeURI(dir)
-    mp.commandv("script-message", callback, utils.format_json(response), ...)
-end)
-
---custom handling for opening directories
-mp.register_script_message("http/open-dir", function(path, flags)
-    flag = flags
-    open_directory(path)
-end)
+return http

--- a/addons/http-browser.lua
+++ b/addons/http-browser.lua
@@ -74,7 +74,7 @@ function http:parse(directory)
         end
     end
 
-    self.state.directory_label = decodeURI(directory)
+    self.set_directory_label( decodeURI(directory) )
     return self.sort(list), true, true
 end
 

--- a/addons/http-browser.lua
+++ b/addons/http-browser.lua
@@ -65,8 +65,8 @@ function http:parse(directory)
         if valid and link:find("[:?<>|]") then valid = false end
 
         local is_dir = (alt == "DIR")
-        if valid and is_dir and not self.valid_dir(link) then valid = false
-        elseif valid and self.valid_file(link) then valid = false end
+        if valid and is_dir and not self.valid_dir(link) then valid = false end
+        if valid and not is_dir and not self.valid_file(link) then valid = false end
 
         if valid then
             msg.trace(alt..": "..link)
@@ -74,7 +74,8 @@ function http:parse(directory)
         end
     end
 
-    return self.sort(list)
+    self.state.directory_label = decodeURI(directory)
+    return self.sort(list), true, true
 end
 
 return http

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -360,7 +360,7 @@ function parser_mt.set_empty_text(text) state.empty_text = text end
 if o.addons then
     local addon_dir = mp.command_native({"expand-path", o.addon_directory..'/'})
     local files = utils.readdir(addon_dir)
-    if not addon_dir then error("could not read addon directory") end
+    if not files then error("could not read addon directory") end
 
     for _, file in ipairs(files) do
         if file:sub(-4) == ".lua" then

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -91,7 +91,6 @@ local state = {
     directory = nil,
     directory_label = nil,
     prev_directory = "",
-    parser = "file",
 
     multiselect_start = nil,
     initial_selection = {},
@@ -142,7 +141,6 @@ local __cache = {
             directory = state.directory,
             directory_label = state.directory_label,
             list = state.list,
-            parser = state.parser,
             selected = state.selected
         })
     end,
@@ -657,7 +655,6 @@ local function goto_root()
     state.directory = ""
     select_prev_directory()
 
-    state.parser = ""
     state.prev_directory = ""
     cache:clear()
     state.selection = {}
@@ -783,7 +780,7 @@ end
 --loads lists or defers the command to add-ons
 local function loadlist(path, flags)
     local parser = choose_parser(path)
-    if parser.type == "file" then
+    if parser == file_parser then
         mp.commandv('loadlist', path, flags == "append-play" and "append" or flags)
         if flags == "append-play" and mp.get_property_bool("core-idle") then mp.commandv("playlist-play-index", 0) end
     else

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -238,8 +238,8 @@ local function filter(t)
         local temp = t[i]
         t[i] = nil
 
-        if  ( temp.type == "dir" and valid_dir(temp.name) ) or
-            ( temp.type == "file" and valid_file(temp.name) )
+        if  ( temp.type == "dir" and valid_dir(temp.label or temp.name) ) or
+            ( temp.type == "file" and valid_file(temp.label or temp.name) )
         then
             t[top] = temp
             top = top+1
@@ -698,7 +698,7 @@ local function goto_root()
 end
 
 local function scan_directory(directory)
-    local list, sorted, filtered = choose_parser(directory):parse(directory)
+    local list, filtered, sorted = choose_parser(directory):parse(directory)
     if not list then return list end
     if filtered ~= true then filter(list) end
     if sorted ~= true then sort(list) end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -245,6 +245,7 @@ local function filter(t)
             top = top+1
         end
     end
+    return t
 end
 
 --sorts a table into an array of selected items in the correct order
@@ -349,6 +350,8 @@ parser_mt.valid_dir = valid_dir
 parser_mt.filter = filter
 parser_mt.sort = sort
 parser_mt.ass_escape = ass_escape
+parser_mt.fix_path = fix_path
+parser_mt.get_extension = get_extension
 
 --providing getter and setter functions so that addons can't modify things directly
 function parser_mt.get_script_opts() return copy_table(o) end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -268,7 +268,10 @@ end
 local function copy_table(t)
     local copy = {}
     for key, value in pairs(t) do
-        copy[key] = type(value) == "table" and copy_table(value) or value
+        if type(value) == "table" then
+            if value == t then copy[key] = copy
+            else copy[key] = copy_table(value) end
+        else copy[key] = value end
     end
     return copy
 end
@@ -371,11 +374,11 @@ if o.addons then
 
     for _, file in ipairs(files) do
         if file:sub(-4) == ".lua" then
-            local addon = setmetatable(dofile(addon_dir..file), parser_mt)
-            addon.name = addon.name or file:sub(1,-5)
-            if type(addon.priority) ~= "number" then error("addon "..file.." needs a numeric priority") end
+            local parser = setmetatable( dofile(addon_dir..file), copy_table(parser_mt) )
+            parser.name = parser.name or file:sub(1,-5)
+            if type(parser.priority) ~= "number" then error("addon "..file.." needs a numeric priority") end
 
-            table.insert(parsers, addon)
+            table.insert(parsers, parser)
         end
     end
     table.sort(parsers, function(a, b) return a.priority < b.priority end)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -292,8 +292,11 @@ local function setup_extensions_list()
     for i=1, #compatible_file_extensions do
         extensions[compatible_file_extensions[i]] = true
     end
+
+    --setting up subtitle extensions
     for i = 1, #subtitle_extensions do
         extensions[subtitle_extensions[i]] = true
+        sub_extensions[subtitle_extensions[i]] = true
     end
 
     --adding extra extensions on the whitelist
@@ -304,11 +307,6 @@ local function setup_extensions_list()
     --removing extensions that are in the blacklist
     for str in string.gmatch(o.extension_blacklist, "([^"..o.root_seperators.."]+)") do
         extensions[str] = nil
-    end
-
-    --setting up subtitle extensions list
-    for i = 1, #subtitle_extensions do
-        sub_extensions[subtitle_extensions[i]] = true
     end
 end
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -87,6 +87,7 @@ local state = {
     hidden = true,
     flag_update = false,
     cursor_style = o.ass_cursor,
+    keybinds = nil,
 
     directory = nil,
     directory_label = nil,
@@ -768,8 +769,64 @@ end
 
 
 ------------------------------------------------------------------------------------------
----------------------------------File/Playlist Opening------------------------------------
 ------------------------------------Browser Controls--------------------------------------
+------------------------------------------------------------------------------------------
+------------------------------------------------------------------------------------------
+
+--opens the browser
+local function open()
+    for _,v in ipairs(state.keybinds) do
+        mp.add_forced_key_binding(v[1], 'dynamic/'..v[2], v[3], v[4])
+    end
+
+    state.hidden = false
+    if state.directory == nil then
+        local path = mp.get_property('path')
+        update_current_directory(nil, path)
+        if path or o.default_to_working_directory then goto_current_dir() else goto_root() end
+        return
+    end
+
+    if state.flag_update then update_current_directory(nil, mp.get_property('path')) end
+    state.hidden = false
+    if not state.flag_update then ass:update()
+    else state.flag_update = false ; update_ass() end
+end
+
+--closes the list and sets the hidden flag
+local function close()
+    for _,v in ipairs(state.keybinds) do
+        mp.remove_key_binding('dynamic/'..v[2])
+    end
+
+    state.hidden = true
+    ass:remove()
+end
+
+--toggles the list
+local function toggle()
+    if state.hidden then open()
+    else close() end
+end
+
+--run when the escape key is used
+local function escape()
+    --if multiple items are selection cancel the
+    --selection instead of closing the browser
+    if next(state.selection) or state.multiselect_start then
+        state.selection = {}
+        disable_select_mode()
+        update_ass()
+        return
+    end
+    close()
+end
+
+
+
+------------------------------------------------------------------------------------------
+---------------------------------File/Playlist Opening------------------------------------
+------------------------------------------------------------------------------------------
 ------------------------------------------------------------------------------------------
 
 --recursive function to load directories using the script custom parsers
@@ -835,55 +892,6 @@ local function loadfile(item, flag, autoload)
         if autoload then autoload_dir(path) end
         return true
     end
-end
-
---opens the browser
-local function open()
-    for _,v in ipairs(state.keybinds) do
-        mp.add_forced_key_binding(v[1], 'dynamic/'..v[2], v[3], v[4])
-    end
-
-    state.hidden = false
-    if state.directory == nil then
-        local path = mp.get_property('path')
-        update_current_directory(nil, path)
-        if path or o.default_to_working_directory then goto_current_dir() else goto_root() end
-        return
-    end
-
-    if state.flag_update then update_current_directory(nil, mp.get_property('path')) end
-    state.hidden = false
-    if not state.flag_update then ass:update()
-    else state.flag_update = false ; update_ass() end
-end
-
---closes the list and sets the hidden flag
-local function close()
-    for _,v in ipairs(state.keybinds) do
-        mp.remove_key_binding('dynamic/'..v[2])
-    end
-
-    state.hidden = true
-    ass:remove()
-end
-
---toggles the list
-local function toggle()
-    if state.hidden then open()
-    else close() end
-end
-
---run when the escape key is used
-local function escape()
-    --if multiple items are selection cancel the
-    --selection instead of closing the browser
-    if next(state.selection) or state.multiselect_start then
-        state.selection = {}
-        disable_select_mode()
-        update_ass()
-        return
-    end
-    close()
 end
 
 --opens the selelected file(s)

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -43,9 +43,10 @@ filter_dot_dirs=no
 filter_dot_files=no
 
 #when loading a directory from the browser use the script's
-#parsing code to load the contents of the folder (using filters and sorting)
+#parsing code to load the contents of the folder (using filters and sorting).
 #this means that files will be added to the playlist identically
-#to how they appear in the browser, rather than leaving it to mpv
+#to how they appear in the browser, rather than leaving it to mpv.
+#addons always use this by necessity
 custom_dir_loading=no
 
 #this option reverses the behaviour of the alt+ENTER keybind
@@ -68,11 +69,9 @@ cursor_icon=➤
 indent_icon=\h\h\h
 
 #enables addons
-http_browser=no
-ftp_browser=no
+addons=no
+addon_directory=~~/script-modules/file-browser-addons
 
-#adds support for dvd-browser (https://github.com/CogentRedTester/mpv-dvd-browser)
-dvd_browser=no
 
 ######################################################################
 # ass tags to change the look of the menu


### PR DESCRIPTION
This is a major rewrite of the addon system.
Instead of each addon communicating with the main script via
script messages, these addons are loaded automatically as modules
from the addon directory. All of the code to detect when a path
is valid for a specific addon can be packaged within an addon
module, and tested automatically. Directory scanning also
uses functions returned by the addon module.

In addition, addons are given access to various options and
utility functions via an addon metatable that is added to each
addon after it is imported.

All of this means it is significantly easier to make additional addons
in the future, and that it is possible for anyone to make one
without needing to modify the base file-browser code.

Todo list:

- [X] implement addon importing
- [X] switch script to use new parsing functions
- [X] move http & ftp browser to new API
- [x] update README with new installation instructions
- [x] write documentation on how to create custom addons