### PR TITLE
Addon API refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The [list](https://github.com/CogentRedTester/mpv-file-browser/blob/master/addon
 and [opts](https://github.com/CogentRedTester/mpv-file-browser/blob/master/addons/addons.md#the-opts-table)
 tables are formatted as json strings through the `mp.utils.format_json` function.
 See [addons.md](addons/addons.md) for how the tables are structured, and what each field means.
+The API_VERSION field of both tables refers to what version of the addon API file browser is using.
 The `response-string` refers to an arbitrary script-message that the tables should be sent to.
 
 This script-message allows other scripts to utilise file-browser's directory parsing capabilities, as well as those of the file-browser addons.

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -163,7 +163,7 @@ None of these values are required, and the opts table can even left as nil when 
 | empty_text      | string  | display this text when the list is empty - can be used for error messages                                                                 |
 | selected_index  | number  | the index of the item on the list to select by default - a.k.a. the cursor position                                                       |
 | already_deferred| boolean | whether or not [defer](#Advanced-Functions) was used to create the list, if so then give up if list is nil - set automatically, but can be manually disabled |
-| index           | number  | index of the parser that successfully returns a list - set automatically, but can be set manually to take ownership (see defer)                       |
+| id              | number  | id of the parser that successfully returns a list - set automatically, but can be set manually to take ownership (see defer)              |
 
 The previous static example, but modified so that file browser does not try to filter or re-order the list:
 
@@ -185,9 +185,9 @@ end
 Therefore, it is more efficient to just immediately jump to the root.
 It is up to the addon author to manually disable this if their use of `defer` conflicts with this assumption.
 
-`index` is used to declare ownership of a page. The name of the parser that has ownership is used for custom-keybinds parser filtering.
-When using `defer` index will be the index of whichever parser first returned a list.
-This is the only situation when a parser may want to set index manually.
+`id` is used to declare ownership of a page. The name of the parser that has ownership is used for custom-keybinds parser filtering.
+When using `defer` id will be the id of whichever parser first returned a list.
+This is the only situation when a parser may want to set id manually.
 
 ## Priority Suggestions
 
@@ -431,8 +431,8 @@ The following are a list of recommendations that will increase the compatability
 * Respect the `sorted` and `filtered` values in the opts table. This may mean calling `sort` or `filter` manually.
 * Think about how to handle the `directory_label` field, especially how it might interract with any virtual paths the parser may be maintaining.
 * Think about what to do if the `directory` field is set. This field is deprecated, so you could probably get away with not handling this.
-* Think if you want your parser to take full ownership of the results of `defer`, if so consider setting `opts.index = self:get_index()`.
-  * Currently this affects custom keybind filtering, though it may be changed in the future.
+* Think if you want your parser to take full ownership of the results of `defer`, if so consider setting `opts.id = self:get_id()`.
+  * Currently this only affects custom keybind filtering, though it may be changed in the future.
 
 The [home-label](https://github.com/CogentRedTester/mpv-file-browser/blob/master/addons/home-label.lua)
 addon provides a good simple example of the safe use of defer. It lets the normal file
@@ -489,8 +489,8 @@ All tables returned by these functions are copies to ensure addons can't break t
 
 | key                        | type     | arguments | returns | description                                                                                                           |
 |----------------------------|----------|-----------|---------|-----------------------------------------------------------------------------------------------------------------------|
-| get_id                     | method   | -         | number  | the unique id of the parser                                                                                           |
-| get_index                  | method   | -         | number  | the index of the parser in order of preference                                                                        |
+| get_id                     | method   | -         | number  | the unique id of the parser - used internally to set ownership of list results for cutom-keybind filtering            |
+| get_index                  | method   | -         | number  | the index of the parser in order of preference - `defer` uses this internally                                         |
 | get_script_opts            | function | -         | table   | the table of script opts set by the user - this never gets changed during runtime                                     |
 | get_root                   | function | -         | table   | the root table - an array of item_tables                                                                              |
 | get_extensions             | function | -         | table   | a set of valid extensions after applying the user's whitelist/blacklist - in the form {ext1 = true, ext2 = true, ...} |

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -111,7 +111,7 @@ Source can have the following values:
 | browser        | triggered by the main browser window                            |
 | loadlist       | the browser is scanning the directory to append to the playlist |
 | script-message | triggered by the `get-directory-contents` script-message        |
-| addon          | caused by an addon calling the `scan_directory` API function - note that addons can set a custom state |
+| addon          | caused by an addon calling the `parse_directory` API function - note that addons can set a custom state |
 
 Note that all calls to any `parse` function during a specific parse request will be given the same parse_state table.
 This theoretically allows parsers to communicate with parsers of a lower priority (or modify how they see source information),
@@ -440,9 +440,9 @@ return parser
 | browse_directory             | function | string                       | -       | clears the cache and opens the given directory in the browser - if the browser is closed then open it                    |
 | update_directory             | function |                              | -       | rescans the current directory - equivalent to Ctrl+r without the cache refresh for higher level directories              |
 | clear_cache                  | function |                              | -       | clears the cache - use if modifying the contents of higher level directories                                             |
-| scan_directory               | function | string, parser_state_table | list_table, opts_table       | starts a new scan for the given directory - note that all parsers are called as normal, so beware infinite recursion     |
+| parse_directory              | function | string, parser_state_table | list_table, opts_table       | starts a new scan for the given directory - note that all parsers are called as normal, so beware infinite recursion     |
 
-Note that the `scan_directory()` function must be called from inside a [coroutine](#coroutines).
+Note that the `parse_directory()` function must be called from inside a [coroutine](#coroutines).
 
 ### Advanced Functions
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -187,7 +187,7 @@ None of these values are required, and the opts table can even left as nil when 
 |-----------------|---------|-------------------------------------------------------------------------------------------------------------------------------------------|
 | filtered        | boolean | if true file-browser will not run the standard filter() function on the list                                                              |
 | sorted          | boolean | if true file-browser will not sort the list                                                                                               |
-| directory       | string  | **[deprecated]** - ges the browser directory to this - used for redirecting to other locations                                            |
+| directory       | string  | changes the browser directory to this - used for redirecting to other locations                                            |
 | directory_label | string  | display this label in the header instead of the actual directory - useful to display encoded paths                                        |
 | empty_text      | string  | display this text when the list is empty - can be used for error messages                                                                 |
 | selected_index  | number  | the index of the item on the list to select by default - a.k.a. the cursor position                                                       |
@@ -466,7 +466,7 @@ The following are a list of recommendations that will increase the compatability
   * If required modify values in the existing opts table, don't create a new one.
 * Respect the `sorted` and `filtered` values in the opts table. This may mean calling `sort` or `filter` manually.
 * Think about how to handle the `directory_label` field, especially how it might interract with any virtual paths the parser may be maintaining.
-* Think about what to do if the `directory` field is set. This field is deprecated, so you could probably get away with not handling this.
+* Think about what to do if the `directory` field is set.
 * Think if you want your parser to take full ownership of the results of `defer`, if so consider setting `opts.id = self:get_id()`.
   * Currently this only affects custom keybind filtering, though it may be changed in the future.
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -95,7 +95,7 @@ The `parse` function is passed a state table as its second argument, this contai
 | key    | type   | description                                   |
 |--------|--------|-----------------------------------------------|
 | source | string | the source of the parse request               |
-| co     | thread | the coroutine running the parse - also found through `coroutine.running()` |
+| directory | string | the directory of the parse request - for debugging purposes |
 | yield  | method | a wrapper around `coroutine.yield()` - see [coroutines](#coroutines) |
 | is_coroutine_current | method | returns if the browser is waiting on the current coroutine to populate the list |
 
@@ -107,6 +107,10 @@ Source can have the following values:
 | loadlist       | the browser is scanning the directory to append to the playlist |
 | script-message | triggered by the `get-directory-contents` script-message        |
 | addon          | caused by an addon calling the `scan_directory` API function - note that addons can set a custom state |
+
+Note that all calls to any `parse` function during a specific parse request will be given the same parse_state table.
+This theoretically allows parsers to communicate with parsers of a lower priority (or modify how they see source information),
+but no guarantees are made that specific keys will remain unused by the API.
 
 #### Coroutines
 
@@ -444,7 +448,7 @@ Note that the `scan_directory()` function must be called from inside a [coroutin
 
 | key           | type     | arguments        | returns                 | description                     |
 |---------------|----------|------------------|-------------------------|---------------------------------|
-| defer         | method   | string, parser_state_table | list_table, opts_table  | forwards the given directory to the next valid parser - can be used to redirect the browser or to modify the results of lower priority parsers |
+| defer         | method   | string | list_table, opts_table  | forwards the given directory to the next valid parser - can be used to redirect the browser or to modify the results of lower priority parsers |
 
 #### Using `defer`
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -444,6 +444,12 @@ return parser
 
 Note that the `parse_directory()` function must be called from inside a [coroutine](#coroutines).
 
+Also note that a limitation of the file-browser internals is that a single coroutine
+cannot be used for multiple parses simultaneously (because
+the coroutine thread object is used to index the parse_state index).
+The `parse_directory()` function handles this by creating a new coroutine for the scan, which
+hands execution back to the original coroutine on completion.
+
 ### Advanced Functions
 
 | key           | type     | arguments        | returns                 | description                     |

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -444,11 +444,10 @@ return parser
 
 Note that the `parse_directory()` function must be called from inside a [coroutine](#coroutines).
 
-Also note that a limitation of the file-browser internals is that a single coroutine
-cannot be used for multiple parses simultaneously (because
-the coroutine thread object is used to index the parse_state index).
-The `parse_directory()` function handles this by creating a new coroutine for the scan, which
-hands execution back to the original coroutine on completion.
+Also note that every parse operation is expected to have its own unique coroutine. This acts as a unique
+ID that can be used internally or by other addons. This means that if multiple `parse_directory` operations
+are run within a single coroutine then file-browser will automatically create a new coroutine for the scan,
+which hands execution back to the original coroutine upon completion.
 
 ### Advanced Functions
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -155,6 +155,7 @@ Each item has the following members:
 | label | string | no       | an alternative string to print to the screen instead of name                              |
 | ass   | string | no       | a string to print to the screen without escaping ass styling - overrides label and name   |
 | path  | string | no       | opening the item uses this full path instead of appending directory and name              |
+| redirect| bool | no       | whether path should redirect the browser when opening a directory - default yes (nil counts as true)|
 
 File-browser expects that `type` and `name` will be set for each item, so leaving these out will probably crash the script.
 File-browser also assumes that all directories end in a `/` when appending name, and that there will be no backslashes.

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -37,8 +37,8 @@ Each addon must return either a single parser table, or an array of parser table
 |-----------|--------|-----------|----------------------------|------------------------------------------------------------------------------------------------------------|
 | priority  | number | -         | -                        | a number to determine what order parsers are tested - see [here](#priority-suggestions) for suggested values |
 | version   | string | -         | -                        | the API version the parser is using - see [API Version](#api-version)                                        |
-| can_parse | method | string    | boolean                    | returns whether or not the given path is compatible with the parser                                        |
-| parse     | method | string, parser_state_table | list_table, opts_table | returns an array of item_tables, and a table of options to control how file_browser handles the list |
+| can_parse | method | string, parse_state_table | boolean                    | returns whether or not the given path is compatible with the parser                                        |
+| parse     | method | string, parse_state_table | list_table, opts_table | returns an array of item_tables, and a table of options to control how file_browser handles the list |
 
 Additionally, each parser can optionally contain:
 
@@ -90,7 +90,7 @@ Please read [coroutines](#coroutines) for all the details.
 
 ### Parse State Table
 
-The `parse` function is passed a state table as its second argument, this contains the following fields.
+The `parse` and `can_parse` functions are passed a state table as its second argument, this contains the following fields.
 
 | key    | type   | description                                   |
 |--------|--------|-----------------------------------------------|

--- a/addons/apache-browser.lua
+++ b/addons/apache-browser.lua
@@ -19,7 +19,8 @@ do
 end
 
 local apache = {
-    priority = 80
+    priority = 80,
+    version = "1.0.0"
 }
 
 function apache:can_parse(name)

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -17,6 +17,7 @@ end
 
 local favourites = nil
 local favs = {
+    version = "1.0.0",
     priority = 30,
     cursor = 1
 }

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -60,7 +60,7 @@ function favs:can_parse(directory)
     return directory:find("Favourites/") == 1
 end
 
-function favs:parse(directory, ...)
+function favs:parse(directory)
     if not favourites then update_favourites() end
     if directory == "Favourites/" then
         local opts = {
@@ -77,7 +77,7 @@ function favs:parse(directory, ...)
 
         local _, finish = directory:find("Favourites/([^/]+/?)")
         local full_path = (full_paths[name] or "")..directory:sub(finish+1)
-        local list, opts = self:defer(full_path or "", ...)
+        local list, opts = self:defer(full_path or "")
 
         if not list then return nil end
         opts.id = self:get_id()
@@ -95,7 +95,7 @@ function favs:parse(directory, ...)
 
     local path = full_paths[ directory:match("([^/]+/?)$") or "" ]
 
-    local list, opts = self:defer(path, ...)
+    local list, opts = self:defer(path)
     if not list then return nil end
     opts.directory = opts.directory or path
     return list, opts

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -29,6 +29,7 @@ local function create_favourite_object(str)
     local item = {
         type = str:sub(-1) == "/" and "dir" or "file",
         path = str,
+        redirect = not use_virtual_directory,
         name = str:match("([^/]+/?)$")
     }
     full_paths[str:match("([^/]+)/?$")] = str

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -79,7 +79,7 @@ function favs:parse(directory, ...)
         local list, opts = self:defer(full_path or "", ...)
 
         if not list then return nil end
-        opts.index = self:get_index()
+        opts.id = self:get_id()
         if opts.directory_label then
             opts.directory_label = opts.directory_label:gsub(full_paths[name], "Favourites/"..name..'/')
             if opts.directory_label:find("Favourites/") ~= 1 then opts.directory_label = nil end

--- a/addons/find.lua
+++ b/addons/find.lua
@@ -14,7 +14,9 @@ local msg = require "mp.msg"
 local browser = require "file-browser"
 local input = require "user-input-module"
 
-local find = {}
+local find = {
+    version = "1.0.0"
+}
 local latest_coroutine = nil
 
 local function compare(name, query)

--- a/addons/ftp-browser.lua
+++ b/addons/ftp-browser.lua
@@ -6,7 +6,8 @@ local mp = require 'mp'
 local msg = require 'mp.msg'
 
 local ftp = {
-    priority = 100
+    priority = 100,
+    version = "1.0.0"
 }
 
 function ftp:can_parse(directory)

--- a/addons/home-label.lua
+++ b/addons/home-label.lua
@@ -8,7 +8,8 @@ local fb = require "file-browser"
 local home = fb.fix_path(mp.command_native({"expand-path", "~/"}), true)
 
 local home_label = {
-    priority = 100
+    priority = 100,
+    version = "1.0.0"
 }
 
 function home_label:can_parse(directory)

--- a/addons/home-label.lua
+++ b/addons/home-label.lua
@@ -16,8 +16,8 @@ function home_label:can_parse(directory)
     return directory:sub(1, home:len()) == home
 end
 
-function home_label:parse(directory, ...)
-    local list, opts = self:defer(directory, ...)
+function home_label:parse(directory)
+    local list, opts = self:defer(directory)
     if (not opts.directory or opts.directory == directory) and not opts.directory_label then
         opts.directory_label = "~/"..(directory:sub(home:len()+1) or "")
     end

--- a/addons/ls.lua
+++ b/addons/ls.lua
@@ -13,13 +13,20 @@ local ls = {
     keybind_name = "file"
 }
 
-local function command(args)
-    local cmd = mp.command_native({
+local function command(args, parse_state)
+    local co = coroutine.running()
+    local cmd = nil
+    mp.command_native_async({
         name = "subprocess",
         playback_only = false,
         capture_stdout = true,
+        capture_stderr = true,
         args = args
-    })
+    }, function(_, res)
+        coroutine.resume_err(co, res)
+    end)
+    if parse_state then cmd = parse_state:yield()
+    else cmd = coroutine.yield() end
 
     return cmd.status == 0 and cmd.stdout or nil
 end
@@ -28,9 +35,9 @@ function ls:can_parse(directory)
     return not self.get_protocol(directory)
 end
 
-function ls:parse(directory)
+function ls:parse(directory, parse_state)
     local list = {}
-    local files = command({"ls", "-1", "-p", "-A", "-N", directory})
+    local files = command({"ls", "-1", "-p", "-A", "-N", directory}, parse_state)
 
     if not files then return nil end
 

--- a/addons/ls.lua
+++ b/addons/ls.lua
@@ -8,6 +8,7 @@ local mp = require "mp"
 
 local ls = {
     priority = 109,
+    version = "1.0.0",
     name = "ls",
     keybind_name = "file"
 }

--- a/addons/m3u-browser.lua
+++ b/addons/m3u-browser.lua
@@ -12,6 +12,7 @@ local rf = require "read-file"
 
 local m3u = {
     priority = 100,
+    version = "1.0.0",
     name = "m3u"
 }
 

--- a/addons/powershell.lua
+++ b/addons/powershell.lua
@@ -15,6 +15,7 @@ local msg = require "mp.msg"
 
 local wn = {
     priority = 109,
+    version = "1.0.0",
     name = "powershell",
     keybind_name = "file"
 }

--- a/addons/powershell.lua
+++ b/addons/powershell.lua
@@ -25,14 +25,20 @@ for _, letter in ipairs(drive_letters) do
     drives[letter] = true
 end
 
-local function command(args)
-    local cmd = mp.command_native({
+local function command(args, parse_state)
+    local co = coroutine.running()
+    local cmd = nil
+    mp.command_native_async({
         name = "subprocess",
         playback_only = false,
         capture_stdout = true,
         capture_stderr = true,
         args = args
-    })
+    }, function(_, res)
+        coroutine.resume_err(co, res)
+    end)
+    if parse_state then cmd = parse_state:yield()
+    else cmd = coroutine.yield() end
 
     return cmd.status == 0 and cmd.stdout or nil, cmd.stderr
 end
@@ -41,7 +47,7 @@ function wn:can_parse(directory)
     return not self.get_protocol(directory) and drives[ directory:sub(1,1) ]
 end
 
-function wn:parse(directory)
+function wn:parse(directory, parse_state)
     local list = {}
     local files, err = command({"powershell", "-noprofile", "-command", [[
         $dirs = Get-ChildItem -LiteralPath ]]..string.format("%q", directory)..[[ -Directory
@@ -59,7 +65,7 @@ function wn:parse(directory)
             [Console]::OpenStandardOutput().Write($u8clip, 0, $u8clip.Length)
             Write-Host ""
         }
-    ]]})
+    ]]}, parse_state)
 
     if not files then msg.debug(err) ; return nil end
 

--- a/addons/url-decode.lua
+++ b/addons/url-decode.lua
@@ -24,8 +24,8 @@ function urldecode:can_parse(directory)
     return self.get_protocol(directory)
 end
 
-function urldecode:parse(directory, ...)
-    local list, opts = self:defer(directory, ...)
+function urldecode:parse(directory)
+    local list, opts = self:defer(directory)
     if opts.directory and not self.get_protocol(opts.directory) then return list, opts end
 
     opts.directory_label = decodeURI(opts.directory_label or (opts.directory or directory))

--- a/addons/url-decode.lua
+++ b/addons/url-decode.lua
@@ -3,7 +3,8 @@
 ]]
 
 local urldecode = {
-    priority = 5
+    priority = 5,
+    version = "1.0.0"
 }
 
 --decodes a URL address

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -264,19 +264,28 @@ local cache = setmetatable({}, { __index = __cache })
 ---------------------------------------Part of the addon API--------------------------------------------
 --------------------------------------------------------------------------------------------------------
 
---resumes a coroutine and prints an error if it was not sucessful
-function coroutine.resume_err(...)
-    local success, err = coroutine.resume(...)
-    if not success then msg.error(err) end
-end
-
 --implements table.pack if on lua 5.1
 if not table.pack then
+    table.unpack = unpack
     function table.pack(...)
         local t = {...}
         t.n = select("#", ...)
         return t
     end
+end
+
+--prints an error if a coroutine returns an error
+--unlike the next function this one still returns the results of coroutine.resume()
+function coroutine.resume_catch(...)
+    local returns = table.pack(coroutine.resume(...))
+    if not returns[1] then msg.error(returns[2]) end
+    return table.unpack(returns, 1, returns.n)
+end
+
+--resumes a coroutine and prints an error if it was not sucessful
+function coroutine.resume_err(...)
+    local success, err = coroutine.resume(...)
+    if not success then msg.error(err) end
 end
 
 --get the full path for the current file

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -745,7 +745,7 @@ local function choose_and_parse(directory, index)
     local parse_state = parse_states[coroutine.running()]
     while list == nil and not parse_state.already_deferred and index <= #parsers do
         parser = parsers[index]
-        if parser:can_parse(directory) then
+        if parser:can_parse(directory, parse_state) then
             msg.debug("attempting parser:", parser:get_id())
             list, opts = parser:parse(directory, parse_state)
         end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -168,6 +168,7 @@ local state = {
     directory = nil,
     directory_label = nil,
     prev_directory = "",
+    co = nil,
 
     multiselect_start = nil,
     initial_selection = {},
@@ -225,7 +226,7 @@ local subtitle_extensions = {
 local __cache = {}
 
 __cache.cached_values = {
-    "directory", "directory_label", "list", "selected", "selection", "parser", "empty_text"
+    "directory", "directory_label", "list", "selected", "selection", "parser", "empty_text", "co"
 }
 
 --inserts latest state values onto the cache stack

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1131,9 +1131,9 @@ local function open_file_coroutine(flag, autoload)
         update_ass()
 
     elseif flag == 'replace' then
-        loadfile(state.list[state.selected], flag, autoload ~= o.autoload, directory)
+        local item = state.list[state.selected]
         down_dir()
-        close()
+        loadfile(item, flag, autoload ~= o.autoload, directory)
     else
         loadfile(state.list[state.selected], flag, false, directory)
     end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1653,6 +1653,7 @@ local function scan_directory_json(directory, response_str)
     msg.verbose(("recieved %q from 'get-directory-contents' script message - returning result to %q"):format(directory, response_str))
 
     local list, opts = scan_directory(directory, { source = "script-message" } )
+    list.API_VERSION, opts.API_VERSION = API_VERSION, API_VERSION
 
     --removes invalid json types from the parser object
     if opts.parser then

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -896,7 +896,10 @@ end
 --rescans the folder and updates the list
 local function update(moving_adjacent)
     --we can only make assumptions about the directory label when moving from adjacent directories
-    if not moving_adjacent then state.directory_label = nil end
+    if not moving_adjacent then
+        state.directory_label = nil
+        cache:clear()
+    end
 
     state.empty_text = "~"
     state.list = {}
@@ -913,7 +916,6 @@ end
 --the base function for moving to a directory
 local function goto_directory(directory)
     state.directory = directory
-    cache:clear()
     update()
 end
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -760,7 +760,7 @@ local function choose_and_parse(directory, index)
 end
 
 --moves through valid parsers until a one returns a list
-local function scan_directory(directory, parse_state)
+local function parse_directory(directory, parse_state)
     msg.verbose("scanning files in", directory)
     parse_state.directory = directory
 
@@ -800,7 +800,7 @@ local function update_list()
         return
     end
     local directory = state.directory
-    local list, opts = scan_directory(state.directory, { source = "browser" })
+    local list, opts = parse_directory(state.directory, { source = "browser" })
 
     --if the running coroutine isn't the one stored in the state variable, then the user
     --changed directories while the coroutine was paused, and this operation should be aborted
@@ -1002,7 +1002,7 @@ end
 
 --recursive function to load directories using the script custom parsers
 local function custom_loadlist_recursive(directory, flag)
-    local list, opts = scan_directory(directory, { source = "loadlist" })
+    local list, opts = parse_directory(directory, { source = "loadlist" })
     if list == root then return end
 
     --if we can't parse the directory then append it and hope mpv fares better
@@ -1379,10 +1379,10 @@ function API.clear_cache()
 end
 
 --a wrapper around scan_directory for addon API
-function API.scan_directory(directory, parser_state)
-    if not parser_state then parser_state = { source = "addon" }
-    elseif not parser_state.source then parser_state.source = "addon" end
-    return scan_directory(directory, parser_state)
+function API.parse_directory(directory, parse_state)
+    if not parse_state then parse_state = { source = "addon" }
+    elseif not parse_state.source then parse_state.source = "addon" end
+    return parse_directory(directory, parse_state)
 end
 
 --register file extensions which can be opened by the browser
@@ -1664,7 +1664,7 @@ local function scan_directory_json(directory, response_str)
     if directory ~= "" then directory = API.fix_path(directory, true) end
     msg.verbose(("recieved %q from 'get-directory-contents' script message - returning result to %q"):format(directory, response_str))
 
-    local list, opts = scan_directory(directory, { source = "script-message" } )
+    local list, opts = parse_directory(directory, { source = "script-message" } )
     list.API_VERSION, opts.API_VERSION = API_VERSION, API_VERSION
 
     --removes invalid json types from the parser object

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1573,6 +1573,18 @@ local function setup_addons()
 
     --we want to store the indexes of the parsers
     for i = #parsers, 1, -1 do parsers[ parsers[i] ].index = i end
+
+    --we want to run the setup functions for each addon
+    for index, parser in ipairs(parsers) do
+        if parser.setup then
+            local success, err = pcall(function() parser:setup() end)
+            if not success then
+                msg.error(err)
+                msg.error("parser", parser:get_id(), "threw an error in the setup method - removing from list of parsers")
+                table.remove(parsers, index)
+            end
+        end
+    end
 end
 
 --sets up the compatible extensions list
@@ -1620,11 +1632,6 @@ setup_parser(file_parser, "file-browser.lua")
 if o.addons then
     --all of the API functions need to be defined before this point for the addons to be able to access them safely
     setup_addons()
-
-    --we want to store the index of each parser and run the setup functions
-    for i = #parsers, 1, -1 do
-        if parsers[i].setup then parsers[i]:setup() end
-    end
 end
 
 --these need to be below the addon setup in case any parsers add custom entries

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -294,8 +294,10 @@ function API.get_full_path(item, dir)
     return (dir or state.directory)..item.name
 end
 
+--gets the path for a new subdirectory, redirects if the path field is set
+--returns the new directory path and a boolean specifying if a redirect happened
 function API.get_new_directory(item, directory)
-    if item.path and item.redirect ~= false then return item.path end
+    if item.path and item.redirect ~= false then return item.path, true end
     if directory == "" then return item.name end
     if directory:sub(-1) == "/" then return directory..item.name end
     return directory.."/"..item.name
@@ -957,11 +959,12 @@ local function down_dir()
     if not current or current.type ~= 'dir' and not parseable_extensions[API.get_extension(current.name, "")] then return end
 
     cache:push()
-    state.directory = API.get_new_directory(current, state.directory)
+    local directory, redirected = API.get_new_directory(current, state.directory)
+    state.directory = directory
 
     --we can make some assumptions about the next directory label when moving up or down
     if state.directory_label then state.directory_label = state.directory_label..(current.label or current.name) end
-    update(true)
+    update(not redirected)
 end
 
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1121,14 +1121,14 @@ local function open_file_coroutine(flag, autoload)
         --reset the selection after
         state.selection = {}
 
+        disable_select_mode()
+        update_ass()
+
         --the currently selected file will be loaded according to the flag
         --the flag variable will be switched to append once a file is loaded
         for i=1, #selection do
             if loadfile(selection[i], flag, autoload, directory) then flag = "append" end
         end
-
-        disable_select_mode()
-        update_ass()
 
     elseif flag == 'replace' then
         local item = state.list[state.selected]

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -294,7 +294,8 @@ function API.get_full_path(item, dir)
     return (dir or state.directory)..item.name
 end
 
-function API.concatenate_path(item, directory)
+function API.get_new_directory(item, directory)
+    if item.path and item.redirect ~= false then return item.path end
     if directory == "" then return item.name end
     if directory:sub(-1) == "/" then return directory..item.name end
     return directory.."/"..item.name
@@ -954,7 +955,7 @@ local function down_dir()
     if not current or current.type ~= 'dir' and not parseable_extensions[API.get_extension(current.name, "")] then return end
 
     cache:push()
-    state.directory = API.concatenate_path(current, state.directory)
+    state.directory = API.get_new_directory(current, state.directory)
 
     --we can make some assumptions about the next directory label when moving up or down
     if state.directory_label then state.directory_label = state.directory_label..(current.label or current.name) end
@@ -1057,7 +1058,7 @@ local function custom_loadlist_recursive(directory, flag)
     for _, item in ipairs(list) do
         if not sub_extensions[ API.get_extension(item.name, "") ] then
             if item.type == "dir" or parseable_extensions[API.get_extension(item.name, "")] then
-                if custom_loadlist_recursive( API.concatenate_path(item, directory) , flag) then flag = "append" end
+                if custom_loadlist_recursive( API.get_new_directory(item, directory) , flag) then flag = "append" end
             else
                 local path = API.get_full_path(item, directory)
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -511,51 +511,6 @@ function parser_mt:defer(directory, state)
     return list, opts
 end
 
---load an external addon
-local function setup_addon(file, path)
-    if file:sub(-4) ~= ".lua" then return msg.verbose(path, "is not a lua file - aborting addon setup") end
-
-    local addon_parsers = dofile(path)
-    if not addon_parsers then return msg.error("addon", path, "did not return a table") end
-
-    --if the table contains a priority key then we assume it isn't an array of parsers
-    if not addon_parsers[1] then addon_parsers = {addon_parsers} end
-
-    for _, parser in ipairs(addon_parsers) do
-        parser = setmetatable(parser, parser_mt)
-        parser.name = parser.name or file:gsub("%-browser%.lua$", ""):gsub("%.lua$", "")
-        set_parser_id(parser)
-
-        msg.verbose("imported parser", parser:get_id(), "from", file)
-
-        --sets missing functions
-        if not parser.can_parse then
-            if parser.parse then parser.can_parse = function() return true end
-            else parser.can_parse = function() return false end end
-        end
-
-        if parser.priority == nil then parser.priority = 0 end
-        if type(parser.priority) ~= "number" then return msg.error("parser", parser:get_id(), "needs a numeric priority") end
-
-        table.insert(parsers, parser)
-    end
-end
-
---loading external addons
-local function setup_addons()
-    local addon_dir = mp.command_native({"expand-path", o.addon_directory..'/'})
-    local files = utils.readdir(addon_dir)
-    if not files then error("could not read addon directory") end
-
-    for _, file in ipairs(files) do
-        setup_addon(file, addon_dir..file)
-    end
-    table.sort(parsers, function(a, b) return a.priority < b.priority end)
-
-    --we want to store the indexes of the parsers
-    for i = #parsers, 1, -1 do parser_index[ parsers[i] ] = i end
-end
-
 --parser object for the root
 --this object is not added to the parsers table so that scripts cannot get access to
 --the root table, which is returned directly by parse()
@@ -1475,6 +1430,51 @@ end
 -----------------------------------------Setup Functions------------------------------------------------
 --------------------------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------
+
+--load an external addon
+local function setup_addon(file, path)
+    if file:sub(-4) ~= ".lua" then return msg.verbose(path, "is not a lua file - aborting addon setup") end
+
+    local addon_parsers = dofile(path)
+    if not addon_parsers then return msg.error("addon", path, "did not return a table") end
+
+    --if the table contains a priority key then we assume it isn't an array of parsers
+    if not addon_parsers[1] then addon_parsers = {addon_parsers} end
+
+    for _, parser in ipairs(addon_parsers) do
+        parser = setmetatable(parser, parser_mt)
+        parser.name = parser.name or file:gsub("%-browser%.lua$", ""):gsub("%.lua$", "")
+        set_parser_id(parser)
+
+        msg.verbose("imported parser", parser:get_id(), "from", file)
+
+        --sets missing functions
+        if not parser.can_parse then
+            if parser.parse then parser.can_parse = function() return true end
+            else parser.can_parse = function() return false end end
+        end
+
+        if parser.priority == nil then parser.priority = 0 end
+        if type(parser.priority) ~= "number" then return msg.error("parser", parser:get_id(), "needs a numeric priority") end
+
+        table.insert(parsers, parser)
+    end
+end
+
+--loading external addons
+local function setup_addons()
+    local addon_dir = mp.command_native({"expand-path", o.addon_directory..'/'})
+    local files = utils.readdir(addon_dir)
+    if not files then error("could not read addon directory") end
+
+    for _, file in ipairs(files) do
+        setup_addon(file, addon_dir..file)
+    end
+    table.sort(parsers, function(a, b) return a.priority < b.priority end)
+
+    --we want to store the indexes of the parsers
+    for i = #parsers, 1, -1 do parser_index[ parsers[i] ] = i end
+end
 
 --sets up the compatible extensions list
 local function setup_extensions_list()

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -853,8 +853,8 @@ local function update(moving_adjacent)
     update_ass()
     state.empty_text = "empty directory"
 
-    --if opening a new directory we want to clear the previous coroutine if it is still running
-    --it is up to addon authors to be able to handle this forced resumption
+    --the directory is always handled within a coroutine to allow addons to
+    --pause execution for asynchronous operations
     state.co = coroutine.create(function() update_list(); update_ass() end)
     local success, err = coroutine.resume(state.co)
     if not success then msg.error(err) end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1480,9 +1480,9 @@ local function check_api_version(parser)
     if not major or not minor then
         return msg.error("Invalid version number")
     elseif major ~= API_MAJOR then
-        return msg.error("parser has wrong major version number, expected", ("v%d.x.x"):format(API_MAJOR), "got", 'v'..version)
+        return msg.error("parser", parser.name, "has wrong major version number, expected", ("v%d.x.x"):format(API_MAJOR), "got", 'v'..version)
     elseif minor > API_MINOR then
-        msg.warn("parser has newer minor version number than API, expected", ("v%d.%d.x"):format(API_MAJOR, API_MINOR), "got", 'v'..version)
+        msg.warn("parser", parser.name, "has newer minor version number than API, expected", ("v%d.%d.x"):format(API_MAJOR, API_MINOR), "got", 'v'..version)
     end
     return true
 end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -770,7 +770,6 @@ local function run_parse(directory, parse_state)
 
     parse_states[co] = parse_state
     local list, opts = choose_and_parse(directory, 1)
-    parse_states[co] = nil
 
     if list == nil then return msg.debug("no successful parsers found") end
     opts.parser = parsers[opts.id]
@@ -781,8 +780,8 @@ local function run_parse(directory, parse_state)
 end
 
 --returns the contents of the given directory using the given parse state
---if a parse is being done recusively then create a new coroutine for it so that
---the states in the parse_states table do not conflict
+--if a coroutine has already been used for a parse then create a new coroutine so that
+--the every parse operation has a unique thread ID
 local function parse_directory(directory, parse_state)
     --in lua 5.1 there is only one return value which will be nil if run from the main thread
     --in lua 5.2 main will be true if running from the main thread

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1475,20 +1475,14 @@ local API_MAJOR, API_MINOR, API_PATCH = API_VERSION:match("(%d+)%.(%d+)%.(%d+)")
 local function check_api_version(parser)
     local version = parser.version or "1.0.0"
 
-    local major, minor, patch = version:match("(%d+)%.(%d+)%.(%d+)")
-    if not major then
-        major, minor = version:match("(%d+)%.(%d+)")
-        patch = 0
-    end
+    local major, minor = version:match("(%d+)%.(%d+)")
 
-    if not major or not minor or not patch then
+    if not major or not minor then
         return msg.error("Invalid version number")
     elseif major ~= API_MAJOR then
         return msg.error("parser has wrong major version number, expected", ("v%d.x.x"):format(API_MAJOR), "got", 'v'..version)
-    elseif minor ~= API_MINOR then
-        msg.warn("parser has wrong minor version number, expected", ("v%d.%d.x"):format(API_MAJOR, API_MINOR), "got", 'v'..version)
-    elseif patch > API_PATCH then
-        msg.warn("parser uses newer patch, current patch number is", ("v%d.%d.%d"):format(API_MAJOR, API_MINOR, API_PATCH), "parser uses", 'v'..version)
+    elseif minor > API_MINOR then
+        msg.warn("parser has newer minor version number than API, expected", ("v%d.%d.x"):format(API_MAJOR, API_MINOR), "got", 'v'..version)
     end
     return true
 end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -121,7 +121,7 @@ end
 local API = {}
 package.loaded["file-browser"] = setmetatable({}, { __index = API })
 
-local parser_API = setmetatable({}, { __index = API })
+local parser_API = setmetatable({}, { __index = package.loaded["file-browser"] })
 local parse_state_API = {}
 
 --------------------------------------------------------------------------------------------------------

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -743,7 +743,7 @@ local function choose_and_parse(directory, index)
     msg.debug("finding parser for", directory)
     local parser, list, opts
     local parse_state = parse_states[coroutine.running()]
-    while list == nil and not ( opts and opts.already_deferred ) and index <= #parsers do
+    while list == nil and not parse_state.already_deferred and index <= #parsers do
         parser = parsers[index]
         if parser:can_parse(directory) then
             msg.debug("attempting parser:", parser:get_id())
@@ -1379,10 +1379,10 @@ function API.clear_cache()
 end
 
 --a wrapper around scan_directory for addon API
-function API.scan_directory(directory, state)
-    if not state then state = { source = "addon" }
-    elseif not state.source then state.source = "addon" end
-    return scan_directory(directory, state)
+function API.scan_directory(directory, parser_state)
+    if not parser_state then parser_state = { source = "addon" }
+    elseif not parser_state.source then parser_state.source = "addon" end
+    return scan_directory(directory, parser_state)
 end
 
 --register file extensions which can be opened by the browser
@@ -1445,6 +1445,7 @@ function parser_API:get_id() return parsers[self].id end
 function parser_API:defer(directory)
     msg.trace("deferring to other parsers...")
     local list, opts = choose_and_parse(directory, self:get_index() + 1)
+    parse_states[coroutine.running()].already_deferred = true
     return list, opts
 end
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1543,6 +1543,7 @@ end
 --loads an addon in a separate environment
 local function load_addon(path)
     local addon_environment = setmetatable({}, { __index = _G })
+    addon_environment._G = addon_environment
     local chunk, err
     if setfenv then
         --since I stupidly named a function loadfile I need to specify the global one

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1528,8 +1528,8 @@ local function setup_parser(parser, file)
     parser = setmetatable(parser, { __index = parser_API })
     parser.name = parser.name or file:gsub("%-browser%.lua$", ""):gsub("%.lua$", "")
 
-    if not check_api_version(parser) then return msg.error("aborting load of parser", parser.name, "from", file) end
     set_parser_id(parser)
+    if not check_api_version(parser) then return msg.error("aborting load of parser", parser:get_id(), "from", file) end
 
     msg.verbose("imported parser", parser:get_id(), "from", file)
 


### PR DESCRIPTION
* Restructures the Addon API code inside the file to be cleaner and easier to understand
* Load all Addons  in a separate global environment
* Improve yield safety for aborted parse operations
* Add methods to the parse state table for detecting aborted coroutines
* Improve documentation about coroutines in `addons.md`
* The opts table returned by `parse` now uses `id` instead of `index`
* How parsers are stored internally has been significantly improved
* Add versioning to the API - allows synchronisation between file-browser and addon updates
*  `parse_state` tables no-longer need to be passed into `defer`, they are now indexed by file-browser
using the coroutine as the key. This provides proper states for all parses that file-browser can use.
* The `already_deferred` value is now stored in the parse_state table.
* Every individual parse operation is now done in a separate coroutine, the coroutine acts as a unique id for the parse.
* The `parse_directory` function will detect if the current coroutine is being re-used and will wrap the request in a new coroutine.
* The item.path field now redirects the browser by default
* fix bugs when appending files asynchronously