### PR TITLE
Implement concurrent recursion when appending items to the playlist

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -551,7 +551,11 @@ local function copy_table_recursive(t, references)
     if type(t) ~= "table" then return t end
     if references[t] then return references[t] end
 
-    local copy = setmetatable( {}, { __original = t } )
+    local mt = {
+        __original = t,
+        __index = getmetatable(t)
+    }
+    local copy = setmetatable({}, mt)
     references[t] = copy
 
     for key, value in pairs(t) do

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1223,7 +1223,7 @@ function concurrent_loadlist_wrapper(directory, opts, prev_dirs, item)
     --command_native_async should use that, events like mp.add_timeout (which coroutine.sleep() uses) should
     --be handled enturely on the Lua side with a table, which has a significantly larger maximum size.
     while (opts.concurrency > o.max_concurrency) do
-        API.coroutine.sleep(0.25)
+        API.coroutine.sleep(0.1)
     end
     opts.concurrency = opts.concurrency + 1
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1346,6 +1346,7 @@ end
 --therefore, we must ensure that any state values that could be used after a loadfile call are saved beforehand
 local function open_file_coroutine(opts)
     if not state.list[state.selected] then return end
+    if opts.flag == 'replace' then close() end
 
     --we want to set the idle option to yes to ensure that if the first item
     --fails to load then the player has a chance to attempt to load further items (for async append operations)
@@ -1368,8 +1369,9 @@ local function open_file_coroutine(opts)
         end
 
     else
-        open_item(state.list[state.selected], opts)
+        local item = state.list[state.selected]
         if opts.flag == "replace" then down_dir() end
+        open_item(item, opts)
     end
 
     if mp.get_property("idle") == "yes" then mp.set_property("idle", idle) end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1219,8 +1219,9 @@ end
 --a wrapper function that ensures the concurrent_loadlist_parse is run correctly
 function concurrent_loadlist_wrapper(directory, opts, prev_dirs, item)
     --ensures that only a set number of concurrent parses are operating at any one time.
-    --if the directories are big enough we might still end up overflowing the
-    --mpv event queue, but it is significantly less likely
+    --the mpv event queue is seemingly limited to 1000 items, but only async mpv actions like
+    --command_native_async should use that, events like mp.add_timeout (which coroutine.sleep() uses) should
+    --be handled enturely on the Lua side with a table, which has a significantly larger maximum size.
     while (opts.concurrency > o.max_concurrency) do
         API.coroutine.sleep(0.25)
     end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1230,12 +1230,8 @@ end
 
 --recursively appends items to the playlist, acts as a consumer to the previous functions producer;
 --if the next directory has not been parsed this function will yield until the parse has completed
-local function concurrent_loadlist_append(list, load_opts, prev_dirs)
+local function concurrent_loadlist_append(list, load_opts)
     local directory = list._directory
-
-    --prevents infinite recursion from the item.path or opts.directory fields
-    if prev_dirs[directory] then return end
-    prev_dirs[directory] = true
 
     for _, item in ipairs(list) do
         if not sub_extensions[ API.get_extension(item.name, "") ]
@@ -1246,7 +1242,7 @@ local function concurrent_loadlist_append(list, load_opts, prev_dirs)
             end
 
             if item.type == "dir" or parseable_extensions[API.get_extension(item.name, "")] then
-                concurrent_loadlist_append(item._sublist, load_opts, prev_dirs)
+                concurrent_loadlist_append(item._sublist, load_opts)
             else
                 loadfile(API.get_full_path(item, directory), load_opts)
             end

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -657,7 +657,7 @@ end
 --detects whether or not to highlight the given entry as being played
 local function highlight_entry(v)
     if current_file.name == nil then return false end
-    if v.type == "dir" or parseable_extensions[API.get_extension(v.name, "")] then
+    if API.parseable_item(v) then
         return current_file.directory:find(API.get_full_path(v), 1, true)
     else
         return current_file.path == API.get_full_path(v)
@@ -869,7 +869,7 @@ end
 local function select_prev_directory()
     if state.prev_directory:find(state.directory, 1, true) == 1 then
         local i = 1
-        while (state.list[i] and (state.list[i].type == "dir" or parseable_extensions[API.get_extension(state.list[i].name, "")])) do
+        while (state.list[i] and API.parseable_item(state.list[i])) do
             if state.prev_directory:find(API.get_full_path(state.list[i]), 1, true) then
                 state.selected = i
                 return
@@ -1082,7 +1082,7 @@ end
 --moves down a directory
 local function down_dir()
     local current = state.list[state.selected]
-    if not current or current.type ~= 'dir' and not parseable_extensions[API.get_extension(current.name, "")] then return end
+    if not current or not API.parseable_item(current) then return end
 
     cache:push()
     local directory, redirected = API.get_new_directory(current, state.directory)
@@ -1246,7 +1246,7 @@ local function concurrent_loadlist_append(list, load_opts)
                 coroutine.yield()
             end
 
-            if item.type == "dir" or parseable_extensions[API.get_extension(item.name, "")] then
+            if API.parseable_item(item) then
                 concurrent_loadlist_append(item._sublist, load_opts)
             else
                 loadfile(API.get_full_path(item, directory), load_opts)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1337,7 +1337,7 @@ local function open_item(item, opts)
         mp.commandv("audio-add", path, opts.flag == "replace" and "select" or "auto")
     else
         if opts.autoload then autoload_dir(path, opts)
-        else loadfile(path, opts.flag) end
+        else loadfile(path, opts) end
     end
 end
 
@@ -1381,7 +1381,7 @@ end
 local function open_file(flag, autoload)
     API.coroutine.run(open_file_coroutine, {
         flag = flag,
-        autoload = (autoload == o.autoload and flag == "replace"),
+        autoload = (autoload ~= o.autoload and flag == "replace"),
         directory = state.directory,
         items_appended = 0
     })

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -26,6 +26,11 @@ wrap=no
 #only show files compatible with mpv in the browser
 filter_files=yes
 
+
+#experimental feature that recurses directories concurrently when appending items to the playlist
+#this feature has the potential for massive performance improvements when using addons with asynchronous IO
+concurrent_recursion=no
+
 #enable custom keybinds
 #the keybind json file must go in ~~/script-opts
 custom_keybinds=no

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -26,10 +26,15 @@ wrap=no
 #only show files compatible with mpv in the browser
 filter_files=yes
 
-
 #experimental feature that recurses directories concurrently when appending items to the playlist
 #this feature has the potential for massive performance improvements when using addons with asynchronous IO
 concurrent_recursion=no
+
+#maximum number of recursions that can run concurrently
+#note that recursions are started whole directories at a time, so a folder with a sufficiently large number of
+#subdirectories can still go over this value
+#if this number is too high it risks overflowing the mpv event queue, which will cause some directories to be dropped entirely
+max_concurrency=100
 
 #enable custom keybinds
 #the keybind json file must go in ~~/script-opts

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -31,8 +31,6 @@ filter_files=yes
 concurrent_recursion=no
 
 #maximum number of recursions that can run concurrently
-#note that recursions are started whole directories at a time, so a folder with a sufficiently large number of
-#subdirectories can still go over this value
 #if this number is too high it risks overflowing the mpv event queue, which will cause some directories to be dropped entirely
 max_concurrency=100
 


### PR DESCRIPTION
When recursing through a directory to append its contents to the playlist run
each parse operation concurrently.

This feature has the potential for massive speed improvements when recursively
opening large directories while using addons with asynchronous IO.
This feature can bring addon performance more in-line with the native
parser (which is usually faster for local filesystems).
Network file systems in particular will benefit from this significantly.

The only downsides compared to the default loadlist that I am currently aware of
are higher CPU load (mpv and file-browser are less responsive), and less-predictable append speeds.
The overall time it takes to append the whole directory tree will certainly be less, but it may take longer
to load the first or any subsequent items.

If the number of concurrent recursions is too high then there is the risk of the mpv event
queue overflowing. The mpv event queue is seemingly limited to 1000 items, but only async
mpv actions like command_native_async should use that, events like mp.add_timeout should
be handled entirely on the Lua side with a table, which has a significantly larger maximum size.
Therefore, as long as the max_concurrency value is kept well below 1000 (to allow for addons
creating more than one event each) we should not be at risk.

If this feature is enabled when not using asynchronous IO the behaviour
should be roughly the same as the default, but performance may degrade slightly.

As this is still an experimental feature it will be disabled by default.