### PR TITLE
Docs rewrite 2

### DIFF
--- a/addons/addons.md
+++ b/addons/addons.md
@@ -746,35 +746,118 @@ These functions allow addons to safely get information from file-browser.
 All tables returned by these functions are copies sent through the [`fb.copy_table`](#fbcopy_tablet-table-depth-number-table)
 function to ensure addons can't accidentally break things.
 
-| key                        | type     | arguments | returns | description                                                                                                           |
-|----------------------------|----------|-----------|---------|-----------------------------------------------------------------------------------------------------------------------|
-| get_id                     | method   | -         | number  | the unique id of the parser - used internally to set ownership of list results for cutom-keybind filtering            |
-| get_index                  | method   | -         | number  | the index of the parser in order of preference - `defer` uses this internally                                         |
-| get_script_opts            | function | -         | table   | the table of script opts set by the user - this never gets changed during runtime                                     |
-| get_opt                    | function | string    | string or number or boolean | returns the script-opt with the given key                                                         |
-| get_parse_state            | function | coroutine | table   | returns the [parse_state table](#parse-state-table) for the given coroutine - if no coroutine is given then it uses `coroutine.running()` |
-| get_root                   | function | -         | table   | the root table - an array of item_tables                                                                              |
-| get_extensions             | function | -         | table   | a set of valid extensions after applying the user's whitelist/blacklist - in the form {ext1 = true, ext2 = true, ...} |
-| get_sub_extensions         | function | -         | table   | like above but with subtitle extensions - note that subtitles show up in the above list as well                       |
-| get_audio_extensions       | function | -         | table   | like above but with audio extensions (ones added as additional tracks) - these all show up in the `get_extensions` list as well |
-| get_parseable_extensions   | function | -         | table   | shows parseable file extensions in the same format as the above functions                                             |
-| get_parsers                | function | -         | table   | an array of the loaded parsers                                                                                        |
-| get_dvd_device             | function | -         | string  | the current dvd-device - formatted to work with file-browser                                                          |
-| get_directory              | function | -         | string  | the current directory open in the browser - formatted to work with file-browser                                       |
-| get_list                   | function | -         | table   | the list_table for the currently open directory                                                                       |
-| get_current_file           | function | -         | table   | a table containing the path of the current open file - in the form {directory = "", name = "", path = ""}             |
-| get_current_parser         | function | -         | string  | the unique id of the parser used for the currently open directory                                                     |
-| get_current_parser_keyname | function | -         | string  | the string name of the parser used for the currently open directory - as used by custom keybinds                      |
-| get_selected_index         | function | -         | number  | the current index of the cursor - if the list is empty this should return 1                                           |
-| get_selected_item          | function | -         | table   | returns the item_table of the currently selected item - returns nil if no item is selected (empty list)               |
-| get_open_status            | function | -         | boolean | returns true if the browser is currently open and false if not                                                        |
-| get_state                  | function | -         | table   | the current state values of the browser - not documented and subject to change at any time - adding a proper getter for anything is a valid request |
+#### `fb.get_audio_extensions`
+
+Returns a set of extensions like [`fb.get_extensions`](#fbget_extensions-table) but for extensions that are opened
+as additional audio tracks.
+All of these are included in `fb.get_extensions`.
+
+#### `fb.get_current_file(): table`
+
+A table containing the path of the current open file in the form:
+`{directory = "/home/me/", name = "bunny.mkv", path = "/home/me/bunny.mkv"}`.
+
+#### `fb.get_current_parser(): string`
+
+The unique id of the parser that successfully parsed the current directory.
+
+#### `fb.get_current_parser_keyname(): string`
+
+The `keybind_name` of the parser that successfully parsed the current directory.
+Used for custom-keybind filtering.
+
+#### `fb.get_directory(): string`
+
+The current directory open in the browser.
+
+#### `fb.get_dvd_device(): string`
+
+The current dvd-device as reported by mpv's `dvd-device` property.
+Formatted to work with file-browser.
+
+#### `fb.get_extensions(): table`
+
+Returns the set of valid extensions after applying the user's whitelist/blacklist options.
+The table is in the form `{ mkv = true, mp3 = true, ... }`.
+Sub extensions, audio extensions, and parseable extensions are all included in this set.
+
+#### `fb.get_list(): list_table`
+
+The list_table currently open in the browser.
+
+#### `fb.get_open_status(): boolean`
+
+Returns true if the browser is currently open and false if not.
+
+#### `fb.get_opt(name: string): string | number | boolean`
+
+Returns the script-opt with the given name.
+
+#### `fb.get_parsers(): table`
+
+Returns a table of all the loaded parsers/addons.
+The formatting of this table in undefined, but it should
+always contain an array of the parsers in order of priority.
+
+#### `fb.get_parse_state(co: coroutine): parse_state_table`
+
+Returns the [parse_state table](#parse-state-table) for the given coroutine
+If no coroutine is given then it uses the running coroutine.
+Every parse operation is guaranteed to have a unique coroutine.
+
+#### `fb.get_parseable_extensions(): table`
+
+Returns a set of extensions like [`fb.get_extensions`](#fbget_extensions-table) but for extensions that are
+treated as parseable by the browser.
+All of these are included in `fb.get_extensions`.
+
+#### `fb.get_root(): list_table`
+
+Returns the root table.
+
+#### `fb.get_script_opts(): table`
+
+The table of script opts set by the user. This currently does not get
+changed during runtime, but that is not guaranteed for future minor version increments.
+
+#### `fb.get_selected_index(): number`
+
+The current index of the cursor.
+Note that it is possible for the cursor to be outside the bounds of the list,
+e.g. if the list is empty this should return 1.
+
+#### `fb.get_selected_item(): item_table | nil`
+
+Returns the item_table of the currently selected item.
+If no item is selected (for example an empty list) then returns nil.
+
+#### `fb.get_state(): table`
+
+Returns the current state values of the browser.
+These are not documented and are subject to change at any time,
+adding a proper getter for anything is a valid request.
+
+#### `fb.get_sub_extensions(): table`
+
+Returns a set of extensions like [`fb.get_extensions`](#fbget_extensions-table) but for extensions that are opened
+as additional subtitle tracks.
+All of these are included in `fb.get_extensions`.
+
+#### `parser:get_id(): string`
+
+The unique id of the parser. Used for log messages and various internal functions.
+
+#### `parser:get_index(): number`
+
+The index of the parser in order of preference (based on the priority value).
+`defer` uses this internally.
 
 ### Setters
 
-| key                        | type     | arguments | returns | description                                                                                                           |
-|----------------------------|----------|-----------|---------|-----------------------------------------------------------------------------------------------------------------------|
-| set_selected_index         | function | number    | number or bool  | sets the cursor position - returns the new index, if the input is not a number return false, if the input is out of bounds move it in bounds |
+#### `fb.set_selected_index(pos: number): number | false`
+
+Sets the cursor position and returns the new index.
+If the input is not a number return false, if the input is out of bounds move it in bounds.
 
 ## Examples
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -622,44 +622,6 @@ end
 return home_label
 ```
 
-#### Using `coroutine.callback`
-
-This function is designed to help streamline asynchronous operations. The best way to explain is with an example:
-
-```lua
-local function execute(args)
-    local _, cmd = coroutine.yield(
-        mp.command_native_async({
-            name = "subprocess",
-            playback_only = false,
-            capture_stdout = true,
-            capture_stderr = true,
-            args = args
-        }, fb.coroutine.callback())
-    )
-
-    return cmd.status == 0 and cmd.stdout or nil
-end
-```
-
-This function uses the mpv [subprocess](https://mpv.io/manual/master/#command-interface-subprocess)
-command to execute some system operation. To prevent the whole script (including file-browser and all addons) from freezing
-it uses the [command_native_async](https://mpv.io/manual/master/#lua-scripting-mp-command-native-async(table-[,fn])) command
-to execute the operation asynchronously and takes a callback function as its second argument.
-
-`coroutine.callback())` will automatically create a callback function to resume whatever coroutine ran the `execute` function.
-Any arguments passed into the callback function (by the async function, not by you) will be passed on to the resume;
-in this case `command_native_async` passes three values into the callback, of which only the second is of interest to me.
-
-The unsaid expectation is that the programmer will yield execution before that callback returns. In this example I
-have placed the `command_native_async` command inside the yield call; this is not necessary, I just did this because I think it
-makes the code look more synchronous.
-
-If you are doing this during a parse operation you could also substitute `coroutine.yield()` with `parse_state:yield()` to abort the parse if the user changed
-browser directories during the asynchronous operation.
-
-If you have no idea what I've been talking about read the [Lua manual on coroutines](https://www.lua.org/manual/5.1/manual.html#2.11).
-
 ### Utility Functions
 
 #### `fb.ass_escape(str: string, newline_sub?: true | string): string`

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -552,21 +552,81 @@ return home_label
 
 ### Utility Functions
 
-| key           | type     | arguments        | returns    | description                                                                                                                                            |
-|---------------|----------|------------------|------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| fix_path      | function | string, boolean  | string     | takes a path and an is_directory boolean and returns a file-browser compatible path                                                                    |
-| join_path     | function | string, string   | string     | a wrapper for `mp.utils.join_path` which adds support for network protocols                                                                            |
-| get_full_path | function | item_table, string | string   | returns the full path of a given item for a given directory - takes into account item.name/item.path, etc                                              |
-| ass_escape    | function | string, string   | string     | returns the string with escaped ass styling codes - the 2nd argument allows optionally replacing newlines with the given string, or `\n` if set to `true`|
-| pattern_escape| function | string           | string     | returns the string with special lua pattern characters escaped                                                                                         |
-| get_extension | function | string, def      | string     | returns the file extension of the given file - returns def if file has no extension                                                                    |
-| get_protocol  | function | string, def      | string     | returns the protocol scheme of the given url (https, ftp, etc) - returns def if path has no url scheme                                                 |
-| valid_file    | function | string           | boolean    | tests if the given filename passes the user set filters (valid extensions and dot files)                                                               |
-| valid_dir     | function | string           | boolean    | tests if the given directory name passes the user set filters (dot directories)                                                                        |
-| filter        | function | list_table       | list_table | iterates through the given list and removes items that don't pass the filters - acts directly on the given list, it does not create a copy             |
-| sort          | function | list_table       | list_table | iterates through the given list and sorts the items using file-browsers sorting algorithm - acts directly on the given list, it does not create a copy |
-| iterate_opt   | function | string           | iterator function | returns an iterator that returns substrings of the given string split by the root separators                                                    |
-| copy_table    | function |table|table| recursively makes a deep copy of the given table and returns it, maintaining any cyclical references - the original table is stored in the `__original` field of the metatable - the original metatable is also copied, but not recursively. The copy behaviour of metatable is subject to change. |
+#### `fb.fix_path(path [, is_directory])`
+
+Takes a path and returns a file-browser compatible path string.
+The optional second argument is a boolean that tells the function to format the path to be a
+directory.
+
+#### `fb.join_path(p1, p2)`
+
+A wrapper around [`mp.utils.join_path`](https://mpv.io/manual/master/#lua-scripting-utils-join-path(p1,-p2))
+which treats paths with network protocols as absolute paths.
+
+#### `fb.get_full_path(item, directory)`
+
+Takes an item table and returns the item's full path assuming it is in the given directory.
+Takes into account `item.name`/`item.path` fields, etc.
+
+#### `fb.ass_escape(str [, newline_sub])`
+
+Returns the `str` string with escaped ass styling codes.
+The optional 2nd argument allows replacing newlines with the given string, or `\n` if set to `true`.
+
+#### `fb.pattern_escape(str)`
+
+Returns the `str` string with Lua special pattern characters escaped.
+
+#### `fb.get_extension(filename [, def])`
+
+Returns the file extension for the string `filename`, or `nil` if there is no extension.
+If `def` is defined then that is returned instead of `nil`.
+
+The full stop is not included in the extension, so `test.mkv` will return `mkv`.
+
+#### `fb.get_protocol(url [, def])`
+
+Returns the protocol scheme for the string `url`, or `nil` if there is no scheme.
+If `def` is defined then that is returned instead of `nil`.
+
+The `://` is not included, so `https://example.com/test.mkv` will return `https`.
+
+#### `fb.valid_file(name)`
+
+Tests if the string `name` passes the user set filters for valid files (extensions/dot files/etc).
+
+#### `fb.valid_dir(name)`
+
+Tests if the string `name` passes the user set filters for valid directories (dot folders/etc).
+
+#### `fb.filter(list)`
+
+Iterates through the given list and removes items that don't pass the user set filters.
+Returns the list but does not create a copy, the `list` table is filtered in-place.
+
+#### `fb.sort(list)`
+
+Iterates through the given list and sorts the items using file-browser's sorting algorithm.
+Returns the list but does not create a copy, the `list` table is sorted in-place.
+
+#### `fb.iterate_opt(opts)`
+
+Takes an options string consisting of a list of items separated by the `root_separators` defined in `file_browser.conf` and
+returns an iterator function that can be used to iterate over each item in the list.
+
+```lua
+local opt = "a,b,zz z"                -- root_separators=,
+for item in fb.iterate_opt(opt) do
+    print(item)                       -- prints: a   b   zz z
+end
+```
+
+#### `fb.copy_table(t)`
+
+Returns a copy of table `t`.
+The copy is done recursively, and any cyclical table references are maintained.
+Additionally, the original table is stored in the `__original` field of the copy's metatable.
+The copy behaviour of the metatable itself is currently subject to change.
 
 ### Getters
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -732,18 +732,19 @@ for item in fb.iterate_opt(opt) do
 end
 ```
 
-#### `fb.copy_table(t: table): table`
+#### `fb.copy_table(t: table, depth?: number): table`
 
 Returns a copy of table `t`.
-The copy is done recursively, and any cyclical table references are maintained.
+The copy is done recursively to the given `depth`, and any cyclical table references are maintained.
+Both keys and values are copied. If `depth` is undefined then it defaults to `math.huge` (infinity).
 Additionally, the original table is stored in the `__original` field of the copy's metatable.
-The copy behaviour of the metatable itself is currently subject to change.
+The copy behaviour of the metatable itself is subject to change, but currently it is not copied.
 
 ### Getters
 
 These functions allow addons to safely get information from file-browser.
-All tables returned by these functions are copies to ensure addons can't break things, but a reference to the original table
-is stored in the `__original` field of the metatable.
+All tables returned by these functions are copies sent through the [`fb.copy_table`](#fbcopy_tablet-table-depth-number-table)
+function to ensure addons can't accidentally break things.
 
 | key                        | type     | arguments | returns | description                                                                                                           |
 |----------------------------|----------|-----------|---------|-----------------------------------------------------------------------------------------------------------------------|

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -552,64 +552,65 @@ return home_label
 
 ### Utility Functions
 
-#### `fb.fix_path(path [, is_directory])`
+#### `fb.fix_path(path: string, is_directory?: boolean): string`
 
 Takes a path and returns a file-browser compatible path string.
 The optional second argument is a boolean that tells the function to format the path to be a
 directory.
 
-#### `fb.join_path(p1, p2)`
+#### `fb.join_path(p1: string, p2: string): string`
 
 A wrapper around [`mp.utils.join_path`](https://mpv.io/manual/master/#lua-scripting-utils-join-path(p1,-p2))
 which treats paths with network protocols as absolute paths.
 
-#### `fb.get_full_path(item, directory)`
+#### `fb.get_full_path(item: item_table, directory?: string): string`
 
 Takes an item table and returns the item's full path assuming it is in the given directory.
 Takes into account `item.name`/`item.path` fields, etc.
+If directory is nil then it uses the currently open directory.
 
-#### `fb.ass_escape(str [, newline_sub])`
+#### `fb.ass_escape(str: string, newline_sub?: true | string): string`
 
 Returns the `str` string with escaped ass styling codes.
 The optional 2nd argument allows replacing newlines with the given string, or `\n` if set to `true`.
 
-#### `fb.pattern_escape(str)`
+#### `fb.pattern_escape(str: string): string`
 
-Returns the `str` string with Lua special pattern characters escaped.
+Returns `str` with Lua special pattern characters escaped.
 
-#### `fb.get_extension(filename [, def])`
+#### `fb.get_extension(filename: string, def?: any): string | def`
 
 Returns the file extension for the string `filename`, or `nil` if there is no extension.
 If `def` is defined then that is returned instead of `nil`.
 
 The full stop is not included in the extension, so `test.mkv` will return `mkv`.
 
-#### `fb.get_protocol(url [, def])`
+#### `fb.get_protocol(url: string, def?: any): string | def`
 
 Returns the protocol scheme for the string `url`, or `nil` if there is no scheme.
 If `def` is defined then that is returned instead of `nil`.
 
 The `://` is not included, so `https://example.com/test.mkv` will return `https`.
 
-#### `fb.valid_file(name)`
+#### `fb.valid_file(name: string): boolean`
 
 Tests if the string `name` passes the user set filters for valid files (extensions/dot files/etc).
 
-#### `fb.valid_dir(name)`
+#### `fb.valid_dir(name: string): boolean`
 
 Tests if the string `name` passes the user set filters for valid directories (dot folders/etc).
 
-#### `fb.filter(list)`
+#### `fb.filter(list: list_table): list_table`
 
 Iterates through the given list and removes items that don't pass the user set filters.
 Returns the list but does not create a copy, the `list` table is filtered in-place.
 
-#### `fb.sort(list)`
+#### `fb.sort(list: list_table): list_table`
 
 Iterates through the given list and sorts the items using file-browser's sorting algorithm.
 Returns the list but does not create a copy, the `list` table is sorted in-place.
 
-#### `fb.iterate_opt(opts)`
+#### `fb.iterate_opt(opts: string): iterator`
 
 Takes an options string consisting of a list of items separated by the `root_separators` defined in `file_browser.conf` and
 returns an iterator function that can be used to iterate over each item in the list.
@@ -621,7 +622,7 @@ for item in fb.iterate_opt(opt) do
 end
 ```
 
-#### `fb.copy_table(t)`
+#### `fb.copy_table(t: table): table`
 
 Returns a copy of table `t`.
 The copy is done recursively, and any cyclical table references are maintained.

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -662,31 +662,29 @@ If you have no idea what I've been talking about read the [Lua manual on corouti
 
 ### Utility Functions
 
+#### `fb.ass_escape(str: string, newline_sub?: true | string): string`
+
+Returns the `str` string with escaped ass styling codes.
+The optional 2nd argument allows replacing newlines with the given string, or `'\\n'` if set to `true`.
+
+#### `fb.copy_table(t: table, depth?: number): table`
+
+Returns a copy of table `t`.
+The copy is done recursively to the given `depth`, and any cyclical table references are maintained.
+Both keys and values are copied. If `depth` is undefined then it defaults to `math.huge` (infinity).
+Additionally, the original table is stored in the `__original` field of the copy's metatable.
+The copy behaviour of the metatable itself is subject to change, but currently it is not copied.
+
+#### `fb.filter(list: list_table): list_table`
+
+Iterates through the given list and removes items that don't pass the user set filters.
+Returns the list but does not create a copy, the `list` table is filtered in-place.
+
 #### `fb.fix_path(path: string, is_directory?: boolean): string`
 
 Takes a path and returns a file-browser compatible path string.
 The optional second argument is a boolean that tells the function to format the path to be a
 directory.
-
-#### `fb.join_path(p1: string, p2: string): string`
-
-A wrapper around [`mp.utils.join_path`](https://mpv.io/manual/master/#lua-scripting-utils-join-path(p1,-p2))
-which treats paths with network protocols as absolute paths.
-
-#### `fb.get_full_path(item: item_table, directory?: string): string`
-
-Takes an item table and returns the item's full path assuming it is in the given directory.
-Takes into account `item.name`/`item.path` fields, etc.
-If directory is nil then it uses the currently open directory.
-
-#### `fb.ass_escape(str: string, newline_sub?: true | string): string`
-
-Returns the `str` string with escaped ass styling codes.
-The optional 2nd argument allows replacing newlines with the given string, or `\n` if set to `true`.
-
-#### `fb.pattern_escape(str: string): string`
-
-Returns `str` with Lua special pattern characters escaped.
 
 #### `fb.get_extension(filename: string, def?: any): string | def`
 
@@ -695,30 +693,18 @@ If `def` is defined then that is returned instead of `nil`.
 
 The full stop is not included in the extension, so `test.mkv` will return `mkv`.
 
+#### `fb.get_full_path(item: item_table, directory?: string): string`
+
+Takes an item table and returns the item's full path assuming it is in the given directory.
+Takes into account `item.name`/`item.path` fields, etc.
+If directory is nil then it uses the currently open directory.
+
 #### `fb.get_protocol(url: string, def?: any): string | def`
 
 Returns the protocol scheme for the string `url`, or `nil` if there is no scheme.
 If `def` is defined then that is returned instead of `nil`.
 
 The `://` is not included, so `https://example.com/test.mkv` will return `https`.
-
-#### `fb.valid_file(name: string): boolean`
-
-Tests if the string `name` passes the user set filters for valid files (extensions/dot files/etc).
-
-#### `fb.valid_dir(name: string): boolean`
-
-Tests if the string `name` passes the user set filters for valid directories (dot folders/etc).
-
-#### `fb.filter(list: list_table): list_table`
-
-Iterates through the given list and removes items that don't pass the user set filters.
-Returns the list but does not create a copy, the `list` table is filtered in-place.
-
-#### `fb.sort(list: list_table): list_table`
-
-Iterates through the given list and sorts the items using file-browser's sorting algorithm.
-Returns the list but does not create a copy, the `list` table is sorted in-place.
 
 #### `fb.iterate_opt(opts: string): iterator`
 
@@ -728,17 +714,31 @@ returns an iterator function that can be used to iterate over each item in the l
 ```lua
 local opt = "a,b,zz z"                -- root_separators=,
 for item in fb.iterate_opt(opt) do
-    print(item)                       -- prints: a   b   zz z
+    print(item)                       -- prints: 'a', 'b', 'zz z'
 end
 ```
 
-#### `fb.copy_table(t: table, depth?: number): table`
+#### `fb.join_path(p1: string, p2: string): string`
 
-Returns a copy of table `t`.
-The copy is done recursively to the given `depth`, and any cyclical table references are maintained.
-Both keys and values are copied. If `depth` is undefined then it defaults to `math.huge` (infinity).
-Additionally, the original table is stored in the `__original` field of the copy's metatable.
-The copy behaviour of the metatable itself is subject to change, but currently it is not copied.
+A wrapper around [`mp.utils.join_path`](https://mpv.io/manual/master/#lua-scripting-utils-join-path(p1,-p2))
+which treats paths with network protocols as absolute paths.
+
+#### `fb.pattern_escape(str: string): string`
+
+Returns `str` with Lua special pattern characters escaped.
+
+#### `fb.sort(list: list_table): list_table`
+
+Iterates through the given list and sorts the items using file-browser's sorting algorithm.
+Returns the list but does not create a copy, the `list` table is sorted in-place.
+
+#### `fb.valid_file(name: string): boolean`
+
+Tests if the string `name` passes the user set filters for valid files (extensions/dot files/etc).
+
+#### `fb.valid_dir(name: string): boolean`
+
+Tests if the string `name` passes the user set filters for valid directories (dot folders/etc).
 
 ### Getters
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -566,7 +566,7 @@ return home_label
 | filter        | function | list_table       | list_table | iterates through the given list and removes items that don't pass the filters - acts directly on the given list, it does not create a copy             |
 | sort          | function | list_table       | list_table | iterates through the given list and sorts the items using file-browsers sorting algorithm - acts directly on the given list, it does not create a copy |
 | iterate_opt   | function | string           | iterator function | returns an iterator that returns substrings of the given string split by the root separators                                                    |
-| copy_table    | function |table|table| recursively makes a deep copy of the given table and returns it, maintaining any cyclical references - the original table is stored in the `__original` field of the metatable|
+| copy_table    | function |table|table| recursively makes a deep copy of the given table and returns it, maintaining any cyclical references - the original table is stored in the `__original` field of the metatable - the original metatable is also copied, but not recursively. The copy behaviour of metatable is subject to change. |
 
 ### Getters
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -561,9 +561,7 @@ local function copy_table_recursive(t, references, depth)
     if type(t) ~= "table" or depth == 0 then return t end
     if references[t] then return references[t] end
 
-    local mt = copy_table_recursive(getmetatable(t), {}, 1) or {}
-    mt.__original = t
-    local copy = setmetatable({}, mt)
+    local copy = setmetatable({}, { __original = t })
     references[t] = copy
 
     for key, value in pairs(t) do
@@ -574,9 +572,9 @@ local function copy_table_recursive(t, references, depth)
 end
 
 --a wrapper around copy_table to provide the reference table
-function API.copy_table(t)
+function API.copy_table(t, depth)
     --this is to handle cyclic table references
-    return copy_table_recursive(t, {}, math.huge)
+    return copy_table_recursive(t, {}, depth or math.huge)
 end
 
 


### PR DESCRIPTION
Rewrites the addon API documentation so that
API functions are no-longer in tables and have proper
function signatures, type annotations, and descriptors.

Also slightly modified the undocumented behaviour of `fb.copy_table`.