### PR TITLE
Implement mouse support (point & click)

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -1480,6 +1480,23 @@ state.keybinds = {
     {'Ctrl+a',      'select_all',   select_all}
 }
 
+local function add_key(key)
+    table.insert(state.keybinds, key)
+end
+
+--default keybinds for the experimental mouse-mode
+if o.mouse_mode then
+    add_key{'WHEEL_DOWN',       'mouse/scroll_down',    function() wheel(1) end}
+    add_key{'WHEEL_UP',         'mouse/scroll_up',      function() wheel(-1) end}
+    add_key{'MBTN_LEFT',        'mouse/down_dir',       down_dir}
+    add_key{'MBTN_RIGHT',       'mouse/up_dir',         up_dir}
+    add_key{'Shift+MBTN_LEFT',  'mouse/play_left',      function() open_file('replace', false) end}
+
+    add_key{'MBTN_MID',         'mouse/play_mid',       function() open_file('replace', false) end}
+    add_key{'Shift+MBTN_MID',   'mouse/play_append',    function() open_file('append-play', false) end}
+    add_key{'Alt+MBTN_MID',     'mouse/play_autoload',  function() open_file('replace', true) end}
+end
+
 --a map of key-keybinds - only saves the latest keybind if multiple have the same key code
 local top_level_keys = {}
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -89,6 +89,9 @@ local o = {
     --directory to load external modules - currently just user-input-module
     module_directory = "~~/script-modules",
 
+    --enable experimental mouse mode
+    mouse_mode = false,
+
     --force file-browser to use a specific text alignment (default: top-left)
     --uses ass tag alignment numbers: https://aegi.vmoe.info/docs/3.0/ASS_Tags/#index23h3
     --set to 0 to use the default mpv osd-align options
@@ -858,7 +861,14 @@ local function toggle_select_mode()
     end
 end
 
-
+--update the selected item based on the mouse position
+local function update_mouse_pos(_, mouse_pos)
+    if not mouse_pos.hover then return end
+    local scale = mp.get_property_number("osd-height", 0) / 720
+    local header_offset = 65
+    state.selected = math.ceil((mouse_pos.y-header_offset) / (25* scale))
+    update_ass()
+end
 
 --------------------------------------------------------------------------------------------------------
 -----------------------------------------Directory Movement---------------------------------------------
@@ -1118,6 +1128,8 @@ local function open()
         mp.add_forced_key_binding(v[1], 'dynamic/'..v[2], v[3], v[4])
     end
 
+    if o.mouse_mode then mp.observe_property("mouse-pos", "native", update_mouse_pos) end
+
     utils.shared_script_property_set("file_browser-open", "yes")
     state.hidden = false
     if state.directory == nil then
@@ -1141,6 +1153,7 @@ local function close()
     end
 
     utils.shared_script_property_set("file_browser-open", "no")
+    if o.mouse_mode then mp.unobserve_property(update_mouse_pos) end
     state.hidden = true
     ass:remove()
 end


### PR DESCRIPTION
This PR implements mouse support. This feature must be enabled with the
script-opt `mouse_mode=yes` and requires mpv v0.33.

I would like to resolve the following issues before merging this PR:
- [ ] Decide on default keybindings
- [ ] Decide on names for keybindings
- [ ] Update README with details of the new mode and bindings
- [ ] Solve the issue of calculating the header offset in the `update_mouse_pos()` function. I want the calculation to work with any header font size, but the maths isn't adding up for some reason.

Any feedback on these issues is welcome.

Resolves #22 