### PR TITLE
feat: use script message to control the osc logo display in idle state

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -89,6 +89,9 @@ local o = {
     --directory to load external modules - currently just user-input-module
     module_directory = "~~/script-modules",
 
+    --turn the OSC idle screen off and on when opening and closing the browser
+    toggle_idlescreen = false,
+
     --force file-browser to use a specific text alignment (default: top-left)
     --uses ass tag alignment numbers: https://aegi.vmoe.info/docs/3.0/ASS_Tags/#index23h3
     --set to 0 to use the default mpv osd-align options
@@ -1120,6 +1123,7 @@ local function open()
     end
 
     utils.shared_script_property_set("file_browser-open", "yes")
+    if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end
     state.hidden = false
     if state.directory == nil then
         local path = mp.get_property('path')
@@ -1142,6 +1146,7 @@ local function close()
     end
 
     utils.shared_script_property_set("file_browser-open", "no")
+    if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'yes', 'no_osd') end
     state.hidden = true
     ass:remove()
 end

--- a/file_browser.conf
+++ b/file_browser.conf
@@ -84,6 +84,9 @@ addon_directory=~~/script-modules/file-browser-addons
 #directory to load external modules - currently just user-input-module
 module_directory=~~/script-modules
 
+#turn the OSC idle screen off and on when opening and closing the browser
+toggle_idlescreen=no
+
 ####################################
 ######### style settings ###########
 ####################################


### PR DESCRIPTION
ref:  https://github.com/CogentRedTester/mpv-file-browser/issues/55, https://github.com/mpv-player/mpv/commit/ec236f7a99754adb95fada8195f25c03c2218545
This will allow automatic control the logo display of osc scripts with have the `osc-idlesereen` feature.
However, since this feature is a recently added function, let's keep `utils.shared_script_property_set`.