### PR TITLE
Api/v1.4.0

### DIFF
--- a/addons/addons.md
+++ b/addons/addons.md
@@ -277,9 +277,9 @@ they use the form `file_browser/dynamic/[parser_ID]/[name]`, where `[parser_id]`
 ### Native Functions vs Command Tables
 
 There are two ways of specifying the behaviour of a keybind.
-In the array form, the 3rd argument is a function to be executed, and in the custom-keybind form the `command` field is a table of mpv input commands to run.
-
-These two ways of specifying commands are independant of how the overall keybind is defined.
+It can be in command table form, as done when using custom-keybind syntax, and it can be done in
+native function form, as done when using the `mp.add_key_binding` syntax.
+However, these two ways of specifying commands are independant of how the overall keybind is defined.
 What this means is that the command field of the custom-keybinds syntax can be an array, and the
 3rd value in the array syntax can be a table of mpv commands.
 
@@ -295,11 +295,13 @@ parser.keybinds = {
     {
         key = "Alt+DEL",
         name = "delete_files",
-        command = main,
-        filter = "files"
+        command = main
     }
 }
 ```
+
+There are some limitations however, not all custom-keybind options are supported when using native functions.
+The supported options are: `key`, `name`, `flags`, `parser`, `passthrough`. The other options can be replicated manually (see below).
 
 ### Keybind Functions
 

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -56,6 +56,7 @@ Here is an extremely simple example of an addon creating a parser table and retu
 
 ```lua
 local parser = {
+    version = '1.0.0',
     priority = 100,
     name = "example"        -- this parser will have the id 'example' or 'example_#' if there are duplicates
 }
@@ -159,7 +160,7 @@ Each item has the following members:
 
 File-browser expects that `type` and `name` will be set for each item, so leaving these out will probably crash the script.
 File-browser also assumes that all directories end in a `/` when appending name, and that there will be no backslashes.
-The API function [`fix_path`](#Utility-Functions) can be used to ensure that paths conform to file-browser rules.
+The API function [`fix_path`](#utility-functions) can be used to ensure that paths conform to file-browser rules.
 
 Here is an example of a static list table being returned by the `parse` method.
 This would allow one to specify a custom list of items.
@@ -510,7 +511,7 @@ The `defer` function is very powerful, and can be used by scripts to create virt
 However, due to how much freedom Lua gives coders, it is impossible for file-browser to ensure that parsers are using defer correctly, which can cause unexpected results.
 The following are a list of recommendations that will increase the compatability with other parsers:
 
-* Always return the opts table that is returned by defer, this can contain important values for file-browser, as described [above](#The-Opts-Table).
+* Always return the opts table that is returned by defer, this can contain important values for file-browser, as described [above](#the-opts-table).
   * If required modify values in the existing opts table, don't create a new one.
 * Respect the `sorted` and `filtered` values in the opts table. This may mean calling `sort` or `filter` manually.
 * Think about how to handle the `directory_label` field, especially how it might interract with any virtual paths the parser may be maintaining.

--- a/addons/addons.md
+++ b/addons/addons.md
@@ -437,7 +437,9 @@ return parser
 | register_parseable_extension | function | string                       | -       | register a file extension that the browser will attempt to open, like a directory - for addons which can parse files     |
 | remove_parseable_extension   | function | string                       | -       | remove a file extension that the browser will attempt to open like a directory                                           |
 | add_default_extension        | function | string                       | -       | adds the given extension to the default extension filter whitelist - can only be run inside setup()                      |
-| insert_root_item             | function | item_table, number(optional) | -       | add an item_table (must be a directory) to the root list at the specified position - if number is nil then append to end |
+| insert_root_item             | function | item_table, number? | -      | add an item_table (must be a directory) to the root list at the specified position - if number is nil then append to end |
+| register_root_item| function| (item_table or string), number? | boolean| registers an item_table or a path string to be added to the root and an optional priority value that determines the position (default is 100) - only adds the item if it is not already in the root and returns a boolean that is true if the item was added and false otherwise |
+| register_root_item           | method   | (item_table or string), number?| -     | a wrapper around the above function which uses the parser's priority value if none is specified                          |
 | browse_directory             | function | string                       | -       | clears the cache and opens the given directory in the browser - if the browser is closed then open it                    |
 | parse_directory              | function | string, parser_state_table | list_table, opts_table       | starts a new scan for the given directory - note that all parsers are called as normal, so beware infinite recursion     |
 

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -17,7 +17,7 @@ end
 
 local favourites = nil
 local favs = {
-    version = "1.2.0",
+    version = "1.4.0",
     priority = 30,
     cursor = 1
 }
@@ -37,12 +37,7 @@ local function create_favourite_object(str)
 end
 
 function favs:setup()
-    local root = self.get_root()
-    local fav_exists = false
-    for _, item in ipairs(root) do
-        if item.name:find("Favourites/?$") then fav_exists = true end
-    end
-    if not fav_exists then self.insert_root_item({name = "Favourites/", label = "Favourites"}, 1) end
+    self:register_root_item('Favourites/')
 end
 
 local function update_favourites()

--- a/addons/root.lua
+++ b/addons/root.lua
@@ -1,0 +1,51 @@
+--[[
+    An addon that loads root items from a `~~/script-opts/file-browser-root.json` file.
+    The contents of this file will override the root script-opt.
+
+    The json file takes the form of a list array as defined by the addon API:
+    https://github.com/CogentRedTester/mpv-file-browser/blob/master/addons/addons.md#the-list-array
+
+    The main purpose of this addon is to allow for users to customise the appearance of their root items
+    using the label or ass fields:
+
+    [
+        { "name": "Favourites/" },
+        { "label": "~/", "name": "C:/Users/User/" },
+        { "label": "1TB HDD", "name": "D:/" },
+        { "ass": "{\\c&H007700&}Green Text", "name": "E:/" },
+        { "label": "FTP Server", name: "ftp://user:password@server.com/" }
+    ]
+
+    Make sure local directories always end with `/`.
+    `path` and `name` behave the same in the root but either name or label should have a value.
+    ASS styling codes: https://aegi.vmoe.info/docs/3.0/ASS_Tags/
+]]
+
+local mp = require 'mp'
+local utils = require 'mp.utils'
+local fb = require 'file-browser'
+
+-- loads the root json file
+local json_path = mp.command_native({'expand-path', '~~/script-opts/file-browser-root.json'})
+local f = assert(io.open(json_path, "r"), 'failed to open '..json_path)
+local root, err = utils.parse_json(f:read("*a"))
+if not root then error(err) end
+
+-- deletes any root values set by the root script-opt
+local original_root = getmetatable(fb.get_root()).__original
+for i in ipairs(original_root) do
+    original_root[i] = nil
+end
+
+local parser = {
+    version = '1.4.0',
+    priority = -math.huge
+}
+
+function parser:setup()
+    for i, v in ipairs(root) do
+        fb.register_root_item(v)
+    end
+end
+
+return parser

--- a/addons/winroot.lua
+++ b/addons/winroot.lua
@@ -28,23 +28,13 @@ local function get_drives()
     return root
 end
 
--- returns true if the given drive is in the given root list
-local function in_root(drive, root)
-    for _, item in ipairs(root) do
-        if item.name == drive then return true end
-    end
-    return false
-end
-
 -- adds windows drives to the root if they are not already present
 local function import_drives()
     local drives = get_drives()
     local root = fb.get_root()
 
     for _, drive in ipairs(drives) do
-        if not in_root(drive, root) then
-            fb.insert_root_item({ name = drive })
-        end
+        fb.register_root_item(drive)
     end
 end
 
@@ -57,7 +47,7 @@ local keybind = {
 }
 
 return {
-    version = '1.3.0', 
+    version = '1.4.0',
     setup = import_drives,
     keybinds = { keybind }
 }

--- a/addons/winroot.lua
+++ b/addons/winroot.lua
@@ -31,7 +31,6 @@ end
 -- adds windows drives to the root if they are not already present
 local function import_drives()
     local drives = get_drives()
-    local root = fb.get_root()
 
     for _, drive in ipairs(drives) do
         fb.register_root_item(drive)

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -589,8 +589,8 @@ end
 --------------------------------------------------------------------------------------------------------
 
 --parser object for the root
---this object is not added to the parsers table so that scripts cannot get access to
---the root table, which is returned directly by parse()
+--not inserted to the parser list as it has special behaviour
+--it does get get added to parsers under it's ID to prevent confusing duplicates
 local root_parser = {
     name = "root",
     priority = math.huge,
@@ -1960,6 +1960,8 @@ local function setup_parser(parser, file)
     if parser.priority == nil then parser.priority = 0 end
     if type(parser.priority) ~= "number" then return msg.error("parser", parser:get_id(), "needs a numeric priority") end
 
+    --the root parser has special behaviour, so it should not be in the list of parsers
+    if parser == root_parser then return end
     table.insert(parsers, parser)
 end
 
@@ -2050,6 +2052,7 @@ end
 setup_root()
 
 setup_parser(file_parser, "file-browser.lua")
+setup_parser(root_parser, 'file-browser.lua')
 if o.addons then
     --all of the API functions need to be defined before this point for the addons to be able to access them safely
     setup_addons()


### PR DESCRIPTION
Adds a new API for addons to register new root items.
Only adds the item to the root if it is not already there,
which allows for users to override the placement of items
with the root script-opt.

Can also specify a priority value to control what order items are
placed relative to each other, and provides a parser method that
uses the parser's priority.

The Favourites, Winroot and a new advanced Root addon demonstrate
the use of this new API.