### PR TITLE
Immutable state

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -252,6 +252,29 @@ local compatible_file_extensions = {
 --------------------------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------
 
+--the values table will be made readonly and set as part of the state - do not use values after passing to this function!
+local function update_state(level, values)
+    local new_mt = { level = level }
+    setmetatable(values, new_mt)
+
+    if level == 0 then
+        state = API.read_only(values)
+        return state
+    end
+
+    --bypasses the readonly reference and grabs the original table and metatable
+    local mutable_state = getmetatable(state).__index
+    local mt = getmetatable(mutable_state)
+
+    --travels up the state chain until it finds a mt of the same level as `level`
+    --this mt will be pointing to a state table of one level lower, which is what we want to point to
+    while (mt.level > level ) do mt = getmetatable(mt.__index) end
+    new_mt.__index = mt.__index
+
+    state = API.read_only(values)
+    return state
+end
+
 --metatable of methods to manage the cache
 local __cache = {}
 

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -626,6 +626,21 @@ function API.copy_table(t, depth)
     return copy_table_recursive(t, {}, depth or math.huge)
 end
 
+--handles the read-only table logic
+do
+    local references = setmetatable({}, { __mode = 'k' })
+    local newindex = function(t, k, v) error(("attempted to assign %s to key %s in read-only table %s"):format(v, k, t)) end
+
+    --returns a read-only reference to the table t
+    function API.read_only(t)
+        if references[t] then return references[t] end
+
+        local ro = setmetatable({}, { __index = t, __newindex = newindex })
+        references[t] = ro
+        return ro
+    end
+end
+
 
 
 --------------------------------------------------------------------------------------------------------

--- a/file-browser.lua
+++ b/file-browser.lua
@@ -652,7 +652,7 @@ end
 --handles the read-only table logic
 do
     local references = setmetatable({}, { __mode = 'k' })
-    local newindex = function(t, k, v) error(("attempted to assign %s to key %s in read-only table %s"):format(v, k, t)) end
+    local newindex = function(t, k, v) error(("attempted to assign `%s` to key `%s` in read-only %s"):format(v, k, t)) end
 
     --returns a read-only reference to the table t
     function API.read_only(t)


### PR DESCRIPTION
This is an experiment to make the main browser state variable immutable via metatables.
This means that any change to the state table results in the creation of a new state table.

The `__index` metamethod is used to layer multiple state tables on top of each other to
optimise this so we aren't duplicating everything when moving the cursor. It also allows
for default opens up the ability for default or fallback state values and will potentially
make some cacheing work better.

This is a very significant refactor, and will require changes to huge areas of code. It may
not be worth it. However, there are numerous areas of the script where state values need
to be cached to prevent changes; the directory cache obviously, but also custom keybind
execution and playlist loading. This is due to the asynchronous nature of parse operations
and keybinds, which means that the global state table can change in the middle of 
these operations. Making state immutable opens up numerous possible ways to simplify
this fragile code and prevent any accidental changes during runtime.