### PR TITLE
Prepare for shared-script-properties removal

### DIFF
--- a/file-browser.lua
+++ b/file-browser.lua
@@ -124,7 +124,9 @@ local o = {
 }
 
 opt.read_options(o, 'file_browser')
-utils.shared_script_property_set("file_browser-open", "no")
+if utils.shared_script_property_set then
+    utils.shared_script_property_set('file_browser-open', 'no')
+end
 mp.set_property('user-data/file_browser/open', 'no')
 
 package.path = mp.command_native({"expand-path", o.module_directory}).."/?.lua;"..package.path
@@ -1184,7 +1186,9 @@ local function open()
         mp.add_forced_key_binding(v[1], 'dynamic/'..v[2], v[3], v[4])
     end
 
-    utils.shared_script_property_set("file_browser-open", "yes")
+    if utils.shared_script_property_set then
+        utils.shared_script_property_set('file_browser-open', 'yes')
+    end
     mp.set_property('user-data/file_browser/open', 'yes')
 
     if o.toggle_idlescreen then mp.commandv('script-message', 'osc-idlescreen', 'no', 'no_osd') end


### PR DESCRIPTION
mpv is about to remove `shared-script-properties`, which will cause `utils.shared_script_property_set` to be nil.
Check for it's existence before calling it.
Ref https://github.com/mpv-player/mpv/pull/12456