### PR TITLE
Update directory-movement.lua

### DIFF
--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -39,7 +39,7 @@ function directory_movement.up_dir()
     if index == nil then g.state.directory = ""
     else g.state.directory = dir:sub(index):reverse() end
 
-    if string.match(g.state.directory, "^%w+://$") then
+    if #cache > 0 and cache[#cache]["directory"] == "" then
         g.state.directory = ""
     end
 


### PR DESCRIPTION
When accessing an address like "ftp://localhost", navigating forwards from there would incorrectly jump to just "ftp://", resulting in an error. The purpose of this commit is to clear the value of g.state.directory when it equals the protocol prefix, to prevent this erroneous behavior.
![Screenshot 2024-04-04 155856](https://github.com/CogentRedTester/mpv-file-browser/assets/43652659/c088f855-723e-45c3-b873-b470404e28d0)
