### PR TITLE
when moving up a directory do not stop on empty protocol schemes

### DIFF
--- a/docs/file_browser.conf
+++ b/docs/file_browser.conf
@@ -77,6 +77,10 @@ autoload_save_current=yes
 # move the browser there even if this option is set to false
 default_to_working_directory=no
 
+# when moving up a directory do not stop on empty protocol schemes like `ftp://`
+# e.g. moving up from `ftp://localhost/` will move straight to the root instead of `ftp://`
+skip_protocol_schemes=yes
+
 # enables addons
 addons=no
 addon_directory=~~/script-modules/file-browser-addons

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -1,6 +1,7 @@
 
 local msg = require 'mp.msg'
 
+local o = require 'modules.options'
 local g = require 'modules.globals'
 local cache = require 'modules.cache'
 local scanning = require 'modules.navigation.scanning'
@@ -29,6 +30,12 @@ end
 --moves up a directory
 function directory_movement.up_dir()
     local parent_dir = g.state.directory:match("^(.-/+)[^/]+/*$") or ""
+
+    if o.skip_protocol_schemes and parent_dir:find("^(%a[%w+-.]*)://$") then
+        directory_movement.goto_root()
+        return;
+    end
+
     g.state.directory = parent_dir
 
     --we can make some assumptions about the next directory label when moving up or down

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -28,19 +28,11 @@ end
 
 --moves up a directory
 function directory_movement.up_dir()
-    local dir = g.state.directory:reverse()
-    local index = dir:find("[/\\]")
-
-    while index == 1 do
-        dir = dir:sub(2)
-        index = dir:find("[/\\]")
-    end
-
-    if index == nil then g.state.directory = ""
-    else g.state.directory = dir:sub(index):reverse() end
+    local parent_dir = g.state.directory:match("^(.-/+)[^/]+/*$") or ""
+    g.state.directory = parent_dir
 
     --we can make some assumptions about the next directory label when moving up or down
-    if g.state.directory_label then g.state.directory_label = string.match(g.state.directory_label, "^(.+/)[^/]+/$") end
+    if g.state.directory_label then g.state.directory_label = string.match(g.state.directory_label, "^(.-/+)[^/]+/*$") end
 
     scanning.rescan(true)
     cache:pop()

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -64,6 +64,10 @@ local o = {
     --move the browser there even if this option is set to false
     default_to_working_directory = false,
 
+    --when moving up a directory do not stop on empty protocol schemes like `ftp://`
+    --e.g. moving up from `ftp://localhost/` will move straight to the root instead of `ftp://`
+    skip_protocol_schemes = true,
+
     --allows custom icons be set for the folder and cursor
     --the `\h` character is a hard space to add padding between the symbol and the text
     folder_icon = [[{\p1}m 6.52 0 l 1.63 0 b 0.73 0 0.01 0.73 0.01 1.63 l 0 11.41 b 0 12.32 0.73 13.05 1.63 13.05 l 14.68 13.05 b 15.58 13.05 16.31 12.32 16.31 11.41 l 16.31 3.26 b 16.31 2.36 15.58 1.63 14.68 1.63 l 8.15 1.63{\p0}\h]],


### PR DESCRIPTION
e.g. moving up from `ftp://localhost/` will move straight to the root instead of `ftp://`

An option has been added to control this behaviour.

First brought up in #104