### PR TITLE
Implement directory mapping API feature

### DIFF
--- a/docs/file_browser.conf
+++ b/docs/file_browser.conf
@@ -91,7 +91,9 @@ skip_protocol_schemes=yes
 
 # map optical device paths to their respective file paths,
 # e.g. mapping bd:// to the value of the bluray-device property
-map_optical_devices=yes
+map_bd_device=yes
+map_dvd_device=yes
+map_cdda_device=yes
 
 # enables addons
 addons=no

--- a/docs/file_browser.conf
+++ b/docs/file_browser.conf
@@ -89,6 +89,10 @@ default_to_working_directory=no
 # e.g. moving up from `ftp://localhost/` will move straight to the root instead of `ftp://`
 skip_protocol_schemes=yes
 
+# map optical device paths to their respective file paths,
+# e.g. mapping bd:// to the value of the bluray-device property
+map_optical_devices=yes
+
 # enables addons
 addons=no
 addon_directory=~~/script-modules/file-browser-addons

--- a/main.lua
+++ b/main.lua
@@ -34,6 +34,8 @@ keybinds.setup_keybinds()
 -- property observers
 mp.observe_property('path', 'string', observers.current_directory)
 mp.observe_property('dvd-device', 'string', observers.dvd_device)
+mp.observe_property('bluray-device', 'string', observers.bd_device)
+mp.observe_property('cdda-device', 'string', observers.cd_device)
 
 -- scripts messages
 mp.register_script_message('=>', script_messages.chain)

--- a/main.lua
+++ b/main.lua
@@ -33,12 +33,9 @@ keybinds.setup_keybinds()
 
 -- property observers
 mp.observe_property('path', 'string', observers.current_directory)
-
-if o.map_optical_devices then
-    mp.observe_property('dvd-device', 'string', observers.dvd_device)
-    mp.observe_property('bluray-device', 'string', observers.bd_device)
-    mp.observe_property('cdda-device', 'string', observers.cd_device) 
-end
+if o.map_dvd_device then mp.observe_property('dvd-device', 'string', observers.dvd_device) end
+if o.map_bd_device then mp.observe_property('bluray-device', 'string', observers.bd_device) end
+if o.map_cdda_device then mp.observe_property('cdda-device', 'string', observers.cd_device) end
 
 -- scripts messages
 mp.register_script_message('=>', script_messages.chain)

--- a/main.lua
+++ b/main.lua
@@ -33,9 +33,12 @@ keybinds.setup_keybinds()
 
 -- property observers
 mp.observe_property('path', 'string', observers.current_directory)
-mp.observe_property('dvd-device', 'string', observers.dvd_device)
-mp.observe_property('bluray-device', 'string', observers.bd_device)
-mp.observe_property('cdda-device', 'string', observers.cd_device)
+
+if o.map_optical_devices then
+    mp.observe_property('dvd-device', 'string', observers.dvd_device)
+    mp.observe_property('bluray-device', 'string', observers.bd_device)
+    mp.observe_property('cdda-device', 'string', observers.cd_device) 
+end
 
 -- scripts messages
 mp.register_script_message('=>', script_messages.chain)

--- a/modules/apis/fb.lua
+++ b/modules/apis/fb.lua
@@ -50,20 +50,22 @@ function fb.insert_root_item(item, pos)
     table.insert(g.root, pos or (#g.root + 1), item)
 end
 
-function fb.register_directory_alias(directory, alias, pattern)
-    if not pattern then alias = '^'..fb_utils.pattern_escape(alias) end
-    g.directory_aliases[alias] = directory
-    msg.verbose('registering directory alias', alias, directory)
+-- add a new mapping to the given directory
+function fb.register_directory_mapping(directory, mapping, pattern)
+    if not pattern then mapping = '^'..fb_utils.pattern_escape(mapping) end
+    g.directory_mappings[mapping] = directory
+    msg.verbose('registering directory alias', mapping, directory)
 
     directory_movement.set_current_file(g.current_file.original_path)
-    return alias
+    return mapping
 end
 
-function fb.remove_all_aliases(directory)
+-- remove all directory mappings that map to the given directory
+function fb.remove_all_mappings(directory)
     local removed = {}
-    for alias, target in pairs(g.directory_aliases) do
+    for alias, target in pairs(g.directory_mappings) do
         if target == directory then
-            g.directory_aliases[alias] = nil
+            g.directory_mappings[alias] = nil
             table.insert(removed, alias)
         end
     end

--- a/modules/apis/fb.lua
+++ b/modules/apis/fb.lua
@@ -49,6 +49,25 @@ function fb.insert_root_item(item, pos)
     table.insert(g.root, pos or (#g.root + 1), item)
 end
 
+function fb.register_directory_alias(directory, alias, pattern)
+    if not pattern then alias = '^'..fb_utils.pattern_escape(alias) end
+    g.directory_aliases[alias] = directory
+    msg.verbose('registering directory alias', alias, directory)
+
+    return alias
+end
+
+function fb.remove_all_aliases(directory)
+    local removed = {}
+    for alias, target in pairs(g.directory_aliases) do
+        if target == directory then
+            g.directory_aliases[alias] = nil
+            table.insert(removed, alias)
+        end
+    end
+    return removed
+end
+
 --a newer API for adding items to the root
 --only adds the item if the same item does not already exist in the root
 --the priority variable is a number that specifies the insertion location

--- a/modules/apis/fb.lua
+++ b/modules/apis/fb.lua
@@ -5,6 +5,7 @@ local o = require 'modules.options'
 local g = require 'modules.globals'
 local fb_utils = require 'modules.utils'
 local ass = require 'modules.ass'
+local directory_movement = require 'modules.navigation.directory-movement'
 local scanning = require 'modules.navigation.scanning'
 local cache = require 'modules.cache'
 local controls = require 'modules.controls'
@@ -54,6 +55,7 @@ function fb.register_directory_alias(directory, alias, pattern)
     g.directory_aliases[alias] = directory
     msg.verbose('registering directory alias', alias, directory)
 
+    directory_movement.set_current_file(g.current_file.original_path)
     return alias
 end
 

--- a/modules/ass.lua
+++ b/modules/ass.lua
@@ -47,9 +47,8 @@ local function highlight_entry(v)
 
     if fb_utils.parseable_item(v) then
         return string.find(g.current_file.directory, full_path, 1, true)
-            or string.find(utils.split_path(g.current_file.original_path), full_path, 1, true)
     else
-        return g.current_file.path == full_path or g.current_file.original_path == full_path
+        return g.current_file.path == full_path
     end
 end
 

--- a/modules/ass.lua
+++ b/modules/ass.lua
@@ -3,6 +3,8 @@
 --------------------------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------
 
+local utils = require 'mp.utils'
+
 local g = require 'modules.globals'
 local o = require 'modules.options'
 local fb_utils = require 'modules.utils'
@@ -40,11 +42,14 @@ end
 
 --detects whether or not to highlight the given entry as being played
 local function highlight_entry(v)
-    if g.current_file.name == nil then return false end
+    if g.current_file.path == nil then return false end
+    local full_path = fb_utils.get_full_path(v)
+
     if fb_utils.parseable_item(v) then
-        return string.find(g.current_file.directory, fb_utils.get_full_path(v), 1, true)
+        return string.find(g.current_file.directory, full_path, 1, true)
+            or string.find(utils.split_path(g.current_file.original_path), full_path, 1, true)
     else
-        return g.current_file.path == fb_utils.get_full_path(v)
+        return g.current_file.path == full_path or g.current_file.original_path == full_path
     end
 end
 

--- a/modules/controls.lua
+++ b/modules/controls.lua
@@ -79,7 +79,7 @@ function controls.browse_directory(directory)
     if directory ~= "" then directory = fb_utils.fix_path(directory, true) end
     msg.verbose('recieved directory from script message: '..directory)
 
-    if directory == "dvd://" then directory = g.dvd_device end
+    directory = fb_utils.resolve_directory_alias(directory)
     movement.goto_directory(directory)
     controls.open()
 end

--- a/modules/controls.lua
+++ b/modules/controls.lua
@@ -79,7 +79,7 @@ function controls.browse_directory(directory)
     if directory ~= "" then directory = fb_utils.fix_path(directory, true) end
     msg.verbose('recieved directory from script message: '..directory)
 
-    directory = fb_utils.resolve_directory_alias(directory)
+    directory = fb_utils.resolve_directory_mapping(directory)
     movement.goto_directory(directory)
     controls.open()
 end

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -80,7 +80,6 @@ globals.audio_extensions = {}
 globals.parseable_extensions = {}
 globals.directory_aliases = {}
 
-globals.dvd_device = nil
 globals.current_file = {
     directory = nil,
     name = nil,

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -84,7 +84,8 @@ globals.dvd_device = nil
 globals.current_file = {
     directory = nil,
     name = nil,
-    path = nil
+    path = nil,
+    original_path = nil,
 }
 
 globals.root = {}

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -78,6 +78,13 @@ globals.extensions = {}
 globals.sub_extensions = {}
 globals.audio_extensions = {}
 globals.parseable_extensions = {}
+
+--This table contains mappings to convert external directories to cannonical
+--locations within the file-browser file tree. The keys of the table are Lua
+--patterns used to evaluate external directory paths. The value is the path
+--that should replace the part of the path than matched the pattern.
+--These mappings should only applied at the edges where external paths are
+--ingested by file-browser.
 globals.directory_mappings = {}
 
 globals.current_file = {

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -78,6 +78,7 @@ globals.extensions = {}
 globals.sub_extensions = {}
 globals.audio_extensions = {}
 globals.parseable_extensions = {}
+globals.directory_aliases = {}
 
 globals.dvd_device = nil
 globals.current_file = {

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -78,7 +78,7 @@ globals.extensions = {}
 globals.sub_extensions = {}
 globals.audio_extensions = {}
 globals.parseable_extensions = {}
-globals.directory_aliases = {}
+globals.directory_mappings = {}
 
 globals.current_file = {
     directory = nil,

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -25,7 +25,7 @@ function directory_movement.set_current_file(filepath)
     local exact_path = fb_utils.join_path(workingDirectory, filepath)
     exact_path = fb_utils.fix_path(exact_path, false)
 
-    local resolved_path = fb_utils.resolve_directory_alias(exact_path)
+    local resolved_path = fb_utils.resolve_directory_mapping(exact_path)
 
     g.current_file.directory, g.current_file.name = utils.split_path(resolved_path)
     g.current_file.original_path = exact_path

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -21,14 +21,11 @@ function directory_movement.set_current_file(filepath)
         return
     end
 
-    local workingDirectory = mp.get_property('working-directory', '')
-    local exact_path = fb_utils.join_path(workingDirectory, filepath)
-    exact_path = fb_utils.fix_path(exact_path, false)
-
-    local resolved_path = fb_utils.resolve_directory_mapping(exact_path)
+    local absolute_path = fb_utils.absolute_path(filepath)
+    local resolved_path = fb_utils.resolve_directory_mapping(absolute_path)
 
     g.current_file.directory, g.current_file.name = utils.split_path(resolved_path)
-    g.current_file.original_path = exact_path
+    g.current_file.original_path = absolute_path
     g.current_file.path = resolved_path
 
     if not g.state.hidden then ass.update_ass()

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -1,13 +1,39 @@
 
+local mp = require 'mp'
 local msg = require 'mp.msg'
+local utils = require 'mp.utils'
 
 local o = require 'modules.options'
 local g = require 'modules.globals'
+local ass = require 'modules.ass'
 local cache = require 'modules.cache'
 local scanning = require 'modules.navigation.scanning'
 local fb_utils = require 'modules.utils'
 
 local directory_movement = {}
+
+function directory_movement.set_current_file(filepath)
+    --if we're in idle mode then we want to open the working directory
+    if filepath == nil then
+        g.current_file.directory = fb_utils.fix_path( mp.get_property("working-directory", ""), true)
+        g.current_file.name = nil
+        g.current_file.path = nil
+        return
+    end
+
+    local workingDirectory = mp.get_property('working-directory', '')
+    local exact_path = fb_utils.join_path(workingDirectory, filepath)
+    exact_path = fb_utils.fix_path(exact_path, false)
+
+    local resolved_path = fb_utils.resolve_directory_alias(exact_path)
+
+    g.current_file.directory, g.current_file.name = utils.split_path(resolved_path)
+    g.current_file.original_path = exact_path
+    g.current_file.path = resolved_path
+
+    if not g.state.hidden then ass.update_ass()
+    else g.state.flag_update = true end
+end
 
 --the base function for moving to a directory
 function directory_movement.goto_directory(directory)

--- a/modules/observers.lua
+++ b/modules/observers.lua
@@ -2,6 +2,7 @@
 local g = require 'modules.globals'
 local fb_utils = require 'modules.utils'
 local directory_movement = require 'modules.navigation.directory-movement'
+local fb = require 'modules.apis.fb'
 
 local observers ={}
 
@@ -12,7 +13,17 @@ end
 
 function observers.dvd_device(_, device)
     if not device or device == "" then device = "/dev/dvd/" end
-    g.dvd_device = fb_utils.fix_path(device, true)
+    fb.register_directory_alias(device, 'dvd://')
+end
+
+function observers.bd_device(_, device)
+    if not device or device == '' then device = '/dev/bd' end
+    fb.register_directory_alias(device, 'bd://')
+end
+
+function observers.cd_device(_, device)
+    if not device or device == '' then device = '/dev/cdrom' end
+    fb.register_directory_alias(device, 'cdda://')
 end
 
 return observers

--- a/modules/observers.lua
+++ b/modules/observers.lua
@@ -1,6 +1,4 @@
 
-local g = require 'modules.globals'
-local fb_utils = require 'modules.utils'
 local directory_movement = require 'modules.navigation.directory-movement'
 local fb = require 'modules.apis.fb'
 
@@ -13,17 +11,17 @@ end
 
 function observers.dvd_device(_, device)
     if not device or device == "" then device = "/dev/dvd/" end
-    fb.register_directory_alias(device, 'dvd://')
+    fb.register_directory_mapping(device, 'dvd://')
 end
 
 function observers.bd_device(_, device)
     if not device or device == '' then device = '/dev/bd' end
-    fb.register_directory_alias(device, 'bd://')
+    fb.register_directory_mapping(device, 'bd://')
 end
 
 function observers.cd_device(_, device)
     if not device or device == '' then device = '/dev/cdrom' end
-    fb.register_directory_alias(device, 'cdda://')
+    fb.register_directory_mapping(device, 'cdda://')
 end
 
 return observers

--- a/modules/observers.lua
+++ b/modules/observers.lua
@@ -1,6 +1,7 @@
 
 local directory_movement = require 'modules.navigation.directory-movement'
 local fb = require 'modules.apis.fb'
+local fb_utils = require 'modules.utils'
 
 local observers ={}
 
@@ -10,18 +11,18 @@ function observers.current_directory(_, filepath)
 end
 
 function observers.dvd_device(_, device)
-    if not device or device == "" then device = "/dev/dvd/" end
-    fb.register_directory_mapping(device, '^dvd://.*', true)
+    if not device or device == "" then device = '/dev/dvd' end
+    fb.register_directory_mapping(fb_utils.absolute_path(device), '^dvd://.*', true)
 end
 
 function observers.bd_device(_, device)
     if not device or device == '' then device = '/dev/bd' end
-    fb.register_directory_mapping(device, '^bd://.*', true)
+    fb.register_directory_mapping(fb_utils.absolute_path(device), '^bd://.*', true)
 end
 
 function observers.cd_device(_, device)
     if not device or device == '' then device = '/dev/cdrom' end
-    fb.register_directory_mapping(device, '^cdda://.*', true)
+    fb.register_directory_mapping(fb_utils.absolute_path(device), '^cdda://.*', true)
 end
 
 return observers

--- a/modules/observers.lua
+++ b/modules/observers.lua
@@ -1,33 +1,13 @@
 
-local mp = require 'mp'
-local utils = require 'mp.utils'
-
 local g = require 'modules.globals'
 local fb_utils = require 'modules.utils'
-local ass = require 'modules.ass'
+local directory_movement = require 'modules.navigation.directory-movement'
 
 local observers ={}
 
 --saves the directory and name of the currently playing file
 function observers.current_directory(_, filepath)
-    --if we're in idle mode then we want to open the working directory
-    if filepath == nil then
-        g.current_file.directory = fb_utils.fix_path( mp.get_property("working-directory", ""), true)
-        g.current_file.name = nil
-        g.current_file.path = nil
-        return
-    elseif filepath:find("dvd://") == 1 then
-        filepath = g.dvd_device..filepath:match("dvd://(.*)")
-    end
-
-    local workingDirectory = mp.get_property('working-directory', '')
-    local exact_path = fb_utils.join_path(workingDirectory, filepath)
-    exact_path = fb_utils.fix_path(exact_path, false)
-    g.current_file.directory, g.current_file.name = utils.split_path(exact_path)
-    g.current_file.path = exact_path
-
-    if not g.state.hidden then ass.update_ass()
-    else g.state.flag_update = true end
+    directory_movement.set_current_file(filepath)
 end
 
 function observers.dvd_device(_, device)

--- a/modules/observers.lua
+++ b/modules/observers.lua
@@ -11,17 +11,17 @@ end
 
 function observers.dvd_device(_, device)
     if not device or device == "" then device = "/dev/dvd/" end
-    fb.register_directory_mapping(device, 'dvd://')
+    fb.register_directory_mapping(device, '^dvd://.*', true)
 end
 
 function observers.bd_device(_, device)
     if not device or device == '' then device = '/dev/bd' end
-    fb.register_directory_mapping(device, 'bd://')
+    fb.register_directory_mapping(device, '^bd://.*', true)
 end
 
 function observers.cd_device(_, device)
     if not device or device == '' then device = '/dev/cdrom' end
-    fb.register_directory_mapping(device, 'cdda://')
+    fb.register_directory_mapping(device, '^cdda://.*', true)
 end
 
 return observers

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -78,7 +78,9 @@ local o = {
 
     --map optical device paths to their respective file paths,
     --e.g. mapping bd:// to the value of the bluray-device property
-    map_optical_devices = true,
+    map_bd_device = true,
+    map_dvd_device = true,
+    map_cdda_device = true,
 
     --allows custom icons be set for the folder and cursor
     --the `\h` character is a hard space to add padding between the symbol and the text

--- a/modules/options.lua
+++ b/modules/options.lua
@@ -76,6 +76,10 @@ local o = {
     --e.g. moving up from `ftp://localhost/` will move straight to the root instead of `ftp://`
     skip_protocol_schemes = true,
 
+    --map optical device paths to their respective file paths,
+    --e.g. mapping bd:// to the value of the bluray-device property
+    map_optical_devices = true,
+
     --allows custom icons be set for the folder and cursor
     --the `\h` character is a hard space to add padding between the symbol and the text
     folder_icon = [[{\p1}m 6.52 0 l 1.63 0 b 0.73 0 0.01 0.73 0.01 1.63 l 0 11.41 b 0 12.32 0.73 13.05 1.63 13.05 l 14.68 13.05 b 15.58 13.05 16.31 12.32 16.31 11.41 l 16.31 3.26 b 16.31 2.36 15.58 1.63 14.68 1.63 l 8.15 1.63{\p0}\h]],

--- a/modules/script-messages.lua
+++ b/modules/script-messages.lua
@@ -19,6 +19,8 @@ function script_messages.get_directory_contents(directory, response_str)
         if directory ~= "" then directory = fb_utils.fix_path(directory, true) end
         msg.verbose(("recieved %q from 'get-directory-contents' script message - returning result to %q"):format(directory, response_str))
 
+        directory = fb_utils.resolve_directory_mapping(directory)
+
         local list, opts = scanning.scan_directory(directory, { source = "script-message" } )
         if opts then opts.API_VERSION = g.API_VERSION end
 

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -227,10 +227,10 @@ end
 
 -- Takes a directory string and resolves any directory aliases,
 -- returning the resolved directory.
-function fb_utils.resolve_directory_alias(directory)
+function fb_utils.resolve_directory_mapping(directory)
     if not directory then return directory end
 
-    for alias, target in pairs(g.directory_aliases) do
+    for alias, target in pairs(g.directory_mappings) do
         local start, finish  = string.find(directory, alias)
         if start then
             msg.debug('alias', alias, 'found for directory', directory, 'changing to', target)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -225,6 +225,28 @@ function fb_utils.parseable_item(item)
     return item.type == "dir" or g.parseable_extensions[fb_utils.get_extension(item.name, "")]
 end
 
+-- Takes a directory string and resolves any directory aliases,
+-- returning the resolved directory.
+function fb_utils.resolve_directory_alias(directory)
+    if not directory then return directory end
+
+    for alias, target in pairs(g.directory_aliases) do
+        local start, finish  = string.find(directory, alias)
+        if start then
+            msg.debug('alias', alias, 'found for directory', directory, 'changing to', target)
+
+            -- if the alias is an exact match then return the target as is
+            if finish == #directory then return target end
+
+            -- else make sure the path is correctly formatted
+            target = fb_utils.fix_path(target, true)
+            return string.gsub(directory, alias, target)
+        end
+    end
+
+    return directory
+end
+
 --removes items and folders from the list
 --this is for addons which can't filter things during their normal processing
 function fb_utils.filter(t)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -188,6 +188,12 @@ function fb_utils.join_path(working, relative)
     return fb_utils.get_protocol(relative) and relative or utils.join_path(working, relative)
 end
 
+--converts the given path into an absolute path and normalises it using fb_utils.fix_path
+function fb_utils.absolute_path(path)
+    local absolute_path = fb_utils.join_path(mp.get_property('working-directory', ''), path)
+    return fb_utils.fix_path(absolute_path)
+end
+
 --sorts the table lexicographically ignoring case and accounting for leading/non-leading zeroes
 --the number format functionality was proposed by github user twophyro, and was presumably taken
 --from here: http://notebook.kulchenko.com/algorithms/alphanumeric-natural-sorting-for-humans-in-lua


### PR DESCRIPTION
This feature allows for mappings to be created between an external path, and a path within file-browser's file tree. It is intended to allow external paths to be resolved to a single canonical location within the file tree.

The only use of this feature within file-browser is to resolve the `bd://`, `dvd://`, and `cdda://` paths to their respective device paths.

This feature may be added as a documented part of the addon API, but is currently experimental. The name of the feature may also change.

Before being merged the specific locations where a mapping is converted into it's canonical path should be documented.