### PR TITLE
winroot: replaces the deprecated wmic command

### DIFF
--- a/addons/winroot.lua
+++ b/addons/winroot.lua
@@ -17,12 +17,12 @@ local function get_drives()
         name = 'subprocess',
         playback_only = false,
         capture_stdout = true,
-        args = {'wmic', 'logicaldisk', 'get', 'caption'}
+        args = {'fsutil', 'fsinfo', 'drives'}
     })
     if result.status ~= 0 then return msg.error('could not read windows root') end
 
     local root = {}
-    for drive in result.stdout:gmatch("%a:") do
+    for drive in result.stdout:gmatch("(%a:)\\") do
         table.insert(root, drive..'/')
     end
     return root


### PR DESCRIPTION
wmic disabled by default since Win11 24H2
![image](https://github.com/user-attachments/assets/a519bc88-f547-49d7-8a7a-5d65d159df5d)
