### PR TITLE
Api/v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following keybinds are set by default
 |-------------|----------------------------------|-------------------------------------------------------------------------------|
 | MENU        | browse-files                     | toggles the browser                                                           |
 | Ctrl+o      | open-browser                     | opens the browser                                                             |
-| Alt+o       | browse-directory/get-user-input  | opens a dialogue box to type in a directory - requires [mpv-user-input](#mpv-user-input) |
+| Alt+o       | browse-directory/get-user-input  | opens a dialogue box to type in a directory - requires [mpv-user-input](#mpv-user-input) when mpv < v0.38 |
 
 The following dynamic keybinds are only set while the browser is open:
 
@@ -174,4 +174,7 @@ See [#55](https://github.com/CogentRedTester/mpv-file-browser/issues/55) for mor
 
 mpv-user-input is a script that provides an API to request text input from the user over the OSD.
 It was built using `console.lua` as a base, so supports almost all the same text input commands.
-If `user-input.lua` is loaded by mpv, and `user-input-module` is in the `~~/script-modules/` directory, then using `Alt+o` will open an input box that can be used to directly enter directories for file-browser to open.
+If `user-input.lua` is loaded by mpv, and `user-input-module` is in the `~~/script-modules/` directory,
+then using `Alt+o` will open an input box that can be used to directly enter directories for file-browser to open.
+
+Mpv v0.38 added the `mp.input` module, which means `mpv-user-input` is no-longer necessary from that version onwards.

--- a/addons/apache-browser.lua
+++ b/addons/apache-browser.lua
@@ -22,7 +22,7 @@ end
 
 local apache = {
     priority = 80,
-    version = "1.1.0"
+    api_version = "1.1.0"
 }
 
 function apache:can_parse(name)

--- a/addons/favourites.lua
+++ b/addons/favourites.lua
@@ -17,7 +17,7 @@ end
 
 local favourites = nil
 local favs = {
-    version = "1.4.0",
+    api_version = "1.4.0",
     priority = 30,
     cursor = 1
 }

--- a/addons/find.lua
+++ b/addons/find.lua
@@ -16,7 +16,7 @@ local input_loaded, input = pcall(require, "mp.input")
 local user_input_loaded, user_input = pcall(require, "user-input-module")
 
 local find = {
-    version = "1.3.0"
+    api_version = "1.3.0"
 }
 local latest_coroutine = nil
 local global_fb_state = getmetatable(fb.get_state()).__original

--- a/addons/ftp-browser.lua
+++ b/addons/ftp-browser.lua
@@ -9,7 +9,7 @@ local fb = require 'file-browser'
 
 local ftp = {
     priority = 100,
-    version = "1.1.0"
+    api_version = "1.1.0"
 }
 
 function ftp:can_parse(directory)

--- a/addons/home-label.lua
+++ b/addons/home-label.lua
@@ -9,7 +9,7 @@ local home = fb.fix_path(mp.command_native({"expand-path", "~/"}), true)
 
 local home_label = {
     priority = 100,
-    version = "1.0.0"
+    api_version = "1.0.0"
 }
 
 function home_label:can_parse(directory)

--- a/addons/last-open-directory.lua
+++ b/addons/last-open-directory.lua
@@ -1,0 +1,56 @@
+--[[
+    An addon for mpv-file-browser which stores the last opened directory and
+    sets it as the opened directory the next time mpv is opened.
+
+    Available at: https://github.com/CogentRedTester/mpv-file-browser/tree/master/addons
+]]--
+
+local mp = require 'mp'
+local msg = require 'mp.msg'
+
+local fb = require 'file-browser'
+
+local state_file = mp.command_native({'expand-path', '~~state/last_opened_directory'})
+msg.verbose('using', state_file)
+
+local function write_directory(directory)
+    local file = io.open(state_file, 'w+')
+
+    if not file then return msg.error('could not open', state_file, 'for writing') end
+
+    directory = directory or fb.get_directory()
+    msg.verbose('writing', directory, 'to', state_file)
+    file:write(directory)
+    file:close()
+end
+
+
+local addon = {
+    version = '1.7.0',
+    priority = 0,
+}
+
+function addon:setup()
+    local file = io.open(state_file, "r")
+    if not file then
+        return msg.error('failed to open', state_file, 'for reading')
+    end
+
+    local dir = file:read("*a")
+    msg.verbose('setting default directory to', dir)
+    fb.browse_directory(dir, false)
+    file:close()
+end
+
+function addon:can_parse(dir, parse_state)
+    if parse_state.source == 'browser' then write_directory(dir) end
+    return false
+end
+
+function addon:parse()
+    return nil
+end
+
+mp.register_event('shutdown', function() write_directory() end)
+
+return addon

--- a/addons/last-open-directory.lua
+++ b/addons/last-open-directory.lua
@@ -26,7 +26,7 @@ end
 
 
 local addon = {
-    version = '1.7.0',
+    api_version = '1.7.0',
     priority = 0,
 }
 

--- a/addons/ls.lua
+++ b/addons/ls.lua
@@ -11,7 +11,7 @@ local fb = require "file-browser"
 
 local ls = {
     priority = 109,
-    version = "1.1.0",
+    api_version = "1.1.0",
     name = "ls",
     keybind_name = "file"
 }

--- a/addons/m3u-browser.lua
+++ b/addons/m3u-browser.lua
@@ -12,7 +12,7 @@ local rf = require "read-file"
 
 local m3u = {
     priority = 100,
-    version = "1.0.0",
+    api_version = "1.0.0",
     name = "m3u"
 }
 

--- a/addons/powershell.lua
+++ b/addons/powershell.lua
@@ -16,7 +16,7 @@ local fb = require "file-browser"
 
 local wn = {
     priority = 109,
-    version = "1.1.0",
+    api_version = "1.1.0",
     name = "powershell",
     keybind_name = "file"
 }

--- a/addons/root.lua
+++ b/addons/root.lua
@@ -48,7 +48,7 @@ local function setup()
 end
 
 return {
-    version = '1.4.0',
+    api_version = '1.4.0',
     setup = setup,
     priority = -1000,
 }

--- a/addons/url-decode.lua
+++ b/addons/url-decode.lua
@@ -4,7 +4,7 @@
 
 local urldecode = {
     priority = 5,
-    version = "1.0.0"
+    api_version = "1.0.0"
 }
 
 --decodes a URL address

--- a/addons/windir.lua
+++ b/addons/windir.lua
@@ -34,7 +34,7 @@ end
 
 local dir = {
     priority = 109,
-    version = "1.1.0",
+    api_version = "1.1.0",
     name = "cmd-dir",
     keybind_name = "file"
 }

--- a/addons/winroot.lua
+++ b/addons/winroot.lua
@@ -46,7 +46,7 @@ local keybind = {
 }
 
 return {
-    version = '1.4.0',
+    api_version = '1.4.0',
     setup = import_drives,
     keybinds = { keybind }
 }

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -639,6 +639,11 @@ Returns the success boolean returned by `coroutine.resume`, but drops all other 
 
 Runs the given function in a new coroutine, passing through any additional arguments.
 
+#### `fb.coroutine.queue(fn: function, ...): coroutine`
+
+Runs the given function in a coroutine when the script next goes idle, passing through
+any additional arguments. The (not yet started) coroutine is returned by the function.
+
 #### `fb.rescan(): void`
 
 Rescans the current directory. Equivalent to Ctrl+r without the cache refresh for higher level directories.

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -443,14 +443,14 @@ The current API version in use by file-browser.
 
 Adds the given extension to the default extension filter whitelist. Can only be run inside the `setup()` method.
 
-#### `fb.browse_directory(directory: string, open_browser: bool = true): void`
+#### `fb.browse_directory(directory: string, open_browser: bool = true): coroutine`
 
 Clears the cache and opens the given directory in the browser.
 If the `open_browser` argument is truthy or `nil` then the browser will be opened
 if it is currently closed. If `open_browser` is `false` then the directory will
 be opened in the background.
-This function is non-blocking, it is possible that the function will return before the directory has finished
-being scanned.
+Returns the coroutine of the upcoming parse operation. The parse is queued and run when the script thread next goes idle,
+allowing one to store this value and use it to identify the triggered parse operation.
 
 This is the equivalent of calling the `browse-directory` script-message.
 
@@ -644,9 +644,11 @@ Runs the given function in a new coroutine, passing through any additional argum
 Runs the given function in a coroutine when the script next goes idle, passing through
 any additional arguments. The (not yet started) coroutine is returned by the function.
 
-#### `fb.rescan(): void`
+#### `fb.rescan(): coroutine`
 
 Rescans the current directory. Equivalent to Ctrl+r without the cache refresh for higher level directories.
+Returns the coroutine of the upcoming parse operation. The parse is queued and run when the script thread next goes idle,
+allowing one to store this value and use it to identify the triggered parse operation.
 
 #### `fb.redraw(): void`
 

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -1,4 +1,4 @@
-# How to Write an Addon - API v1.6.0
+# How to Write an Addon - API v1.7.0
 
 Addons provide ways for file-browser to parse non-native directory structures. This document describes how one can create their own custom addon.
 
@@ -17,7 +17,7 @@ version of the API. It follows [semantic versioning](https://semver.org/) conven
 A parser sets its version string with the `version` field, as seen [below](#overview).
 
 Any change that breaks backwards compatability will cause the major version number to increase.
-A parser MUST have the same version number as the API, otherwise an error message will be printed and the parser will
+A parser MUST have the same major version number as the API, otherwise an error message will be printed and the parser will
 not be loaded.
 
 A minor version number denotes a change to the API that is backwards compatible. This includes additional API functions,
@@ -36,7 +36,7 @@ Each addon must return either a single parser table, or an array of parser table
 | key       | type   | arguments                 | returns                | description                                                                                                  |
 |-----------|--------|---------------------------|------------------------|--------------------------------------------------------------------------------------------------------------|
 | priority  | number | -                         | -                      | a number to determine what order parsers are tested - see [here](#priority-suggestions) for suggested values |
-| version   | string | -                         | -                      | the API version the parser is using - see [API Version](#api-version)                                        |
+| api_version| string | -                         | -                      | the API version the parser is using - see [API Version](#api-version)                                        |
 | can_parse | method | string, parse_state_table | boolean                | returns whether or not the given path is compatible with the parser                                          |
 | parse     | method | string, parse_state_table | list_table, opts_table | returns an array of item_tables, and a table of options to control how file_browser handles the list         |
 
@@ -56,7 +56,7 @@ Here is an extremely simple example of an addon creating a parser table and retu
 
 ```lua
 local parser = {
-    version = '1.0.0',
+    api_version = '1.0.0',
     priority = 100,
     name = "example"        -- this parser will have the id 'example' or 'example_#' if there are duplicates
 }
@@ -674,7 +674,7 @@ local fb = require "file-browser"
 local home = fb.fix_path(mp.command_native({"expand-path", "~/"}), true)
 
 local home_label = {
-    version = '1.0.0',
+    api_version = '1.0.0',
     priority = 100
 }
 

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -717,6 +717,42 @@ Both keys and values are copied. If `depth` is undefined then it defaults to `ma
 Additionally, the original table is stored in the `__original` field of the copy's metatable.
 The copy behaviour of the metatable itself is subject to change, but currently it is not copied.
 
+#### `fb.evaluate_string(str: string, chunkname?: string, env?: table, defaults?: bool = true): unknown`
+
+Loads `str` as a chunk of Lua statement(s) and runs them, returning the result.
+Errors are propagated to the caller. `chunkname` is used
+for debug output and error messages.
+
+Each chunk has a separate global environment table that inherits
+from the main global table. This means new globals can be created safely,
+but the default globals can still be accessed. As such, this method
+cannot and should not be used for security or sandboxing.
+
+A custom environment table can be provided with the `env` argument.
+Inheritance from the global table is disabled if `defaults` is `false`.
+
+Examples:
+
+```lua
+fb.evaluate_string('return 5 + 5')          -- 10
+fb.evaluate_string('x = 20 ; return x * x') -- 400
+
+local code = [[
+local arr = {1, 2, 3, 4}
+table.insert(arr, x)
+return unpack(arr)
+]]
+fb.evaluate_string(code, 'test3', {x = 5})      -- 1, 2, 3, 4, 5
+fb.evaluate_string(code, 'test4', nil, false)   -- Lua error: [string "test4"]:2: attempt to index global 'table' (a nil value)
+
+```
+
+In an expression the `mp`, `mp.msg`, and `mp.utils` modules are available as `mp`, `msg`, and `utils` respectively.
+Additionally, in mpv v0.38+ the `mp.input` module is available as `input`.
+This addon API is available as `fb` and if [mpv-user-input](https://github.com/CogentRedTester/mpv-user-input)
+is installed then user-input will be available in `user_input`.
+These modules are all unavailable if `defaults` is `false`.
+
 #### `fb.filter(list: list_table): list_table`
 
 Iterates through the given list and removes items that don't pass the user set filters

--- a/docs/addons.md
+++ b/docs/addons.md
@@ -443,9 +443,12 @@ The current API version in use by file-browser.
 
 Adds the given extension to the default extension filter whitelist. Can only be run inside the `setup()` method.
 
-#### `fb.browse_directory(directory: string): void`
+#### `fb.browse_directory(directory: string, open_browser: bool = true): void`
 
-Clears the cache and opens the given directory in the browser. If the browser is closed then it will be opened.
+Clears the cache and opens the given directory in the browser.
+If the `open_browser` argument is truthy or `nil` then the browser will be opened
+if it is currently closed. If `open_browser` is `false` then the directory will
+be opened in the background.
 This function is non-blocking, it is possible that the function will return before the directory has finished
 being scanned.
 

--- a/docs/custom-keybinds.md
+++ b/docs/custom-keybinds.md
@@ -176,8 +176,10 @@ To avoid conflicts custom keybinds use the format: `file_browser/dynamic/custom/
 Expressions are used to evaluate Lua code into a string that can be used for commands.
 These behave similarly to those used for [`profile-cond`](https://mpv.io/manual/master/#conditional-auto-profiles)
 values. In an expression the `mp`, `mp.msg`, and `mp.utils` modules are available as `mp`, `msg`, and `utils` respectively.
-Additionally the file-browser [addon API](addons/addons.md#the-api) is available as `fb` and if [mpv-user-input](https://github.com/CogentRedTester/mpv-user-input)
-is installed then user-input API will be available in `input`.
+Additionally, in mpv v0.38+ the `mp.input` module is available as `input`.
+
+The file-browser [addon API](addons/addons.md#the-api) is available as `fb` and if [mpv-user-input](https://github.com/CogentRedTester/mpv-user-input)
+is installed then user-input API will be available in `user_input`.
 
 This example only runs the keybind if the browser is in the Windows C drive or if
 the selected item is a matroska file:
@@ -302,9 +304,9 @@ rename items in file-browser:
 {
     "key": "KP1",
     "command": ["script-message", "run-statement",
-                    "assert(input, 'install mpv-user-input!')",
+                    "assert(user_input, 'install mpv-user-input!')",
 
-                    "local line, err = input.get_user_input_co({",
+                    "local line, err = user_input.get_user_input_co({",
                                             "id = 'rename-file',",
                                             "source = 'custom-keybind',",
                                             "request_text = 'rename file:',",

--- a/docs/custom-keybinds.md
+++ b/docs/custom-keybinds.md
@@ -20,6 +20,7 @@ Keybinds are declared in the `~~/script-opts/file-browser-keybinds.json` file, t
 | delay         | no       | `0`        | time to wait between sending repeated multi commands                                       |
 | concat-string | no       | `' '` (space) | string to insert between items when concatenating multi commands                        |
 | passthrough   | no       | -          | force or ban passthrough behaviour - see [passthrough](#passthrough-keybinds)              |
+| api_version   | no       | -          | tie the keybind to a particular [addon API version](./addons.md#api-version), printing warnings and throwing errors if the keybind is used with wrong versions |
 
 Example:
 

--- a/main.lua
+++ b/main.lua
@@ -11,6 +11,10 @@
 local mp = require 'mp'
 
 local o = require 'modules.options'
+
+-- setting the package paths
+package.path = mp.command_native({"expand-path", o.module_directory}).."/?.lua;"..package.path
+
 local addons = require 'modules.addons'
 local keybinds = require 'modules.keybinds'
 local setup = require 'modules.setup'
@@ -18,8 +22,6 @@ local controls = require 'modules.controls'
 local observers = require 'modules.observers'
 local script_messages = require 'modules.script-messages'
 
--- setting the package paths
-package.path = mp.command_native({"expand-path", o.module_directory}).."/?.lua;"..package.path
 local input_loaded, input = pcall(require, "mp.input")
 local user_input_loaded, user_input = pcall(require, "user-input-module")
 

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -19,6 +19,7 @@ local function check_api_version(parser, id)
     end
 
     local version = parser.api_version
+    if type(version) ~= 'string' then return msg.error(("%s: field `api_version` must be a string, got %s"):format(id, tostring(version))) end
 
     local major, minor = version:match("(%d+)%.(%d+)")
     major, minor = tonumber(major), tonumber(minor)
@@ -118,6 +119,7 @@ local function setup_addon(file, path)
     if file:sub(-4) ~= ".lua" then return msg.verbose(path, "is not a lua file - aborting addon setup") end
 
     local addon_parsers = run_addon(path)
+    if addon_parsers and not next(addon_parsers) then return msg.verbose('addon', path, 'returned empry table - special case, ignoring') end
     if not addon_parsers or type(addon_parsers) ~= "table" then return msg.error("addon", path, "did not return a table") end
 
     --if the table contains a priority key then we assume it isn't an array of parsers

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -11,7 +11,12 @@ local parser_API = require 'modules.apis.parser'
 local API_MAJOR, API_MINOR, API_PATCH = g.API_VERSION:match("(%d+)%.(%d+)%.(%d+)")
 
 --checks if the given parser has a valid version number
-local function check_api_version(parser)
+local function check_api_version(parser, file)
+    if parser.version then
+        msg.warn(('%q: use of the `version` field is deprecated - use `api_version` instead'):format(file))
+        parser.api_version = parser.version
+    end
+
     local version = parser.version or "1.0.0"
 
     local major, minor = version:match("(%d+)%.(%d+)")
@@ -90,7 +95,7 @@ local function setup_parser(parser, file)
     parser.name = parser.name or file:gsub("%-browser%.lua$", ""):gsub("%.lua$", "")
 
     set_parser_id(parser)
-    if not check_api_version(parser) then return msg.error("aborting load of parser", parser:get_id(), "from", file) end
+    if not check_api_version(parser, file) then return msg.error("aborting load of parser", parser:get_id(), "from", file) end
 
     msg.verbose("imported parser", parser:get_id(), "from", file)
 

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -9,6 +9,7 @@ local fb_utils = require 'modules.utils'
 local parser_API = require 'modules.apis.parser'
 
 local API_MAJOR, API_MINOR, API_PATCH = g.API_VERSION:match("(%d+)%.(%d+)%.(%d+)")
+API_MAJOR, API_MINOR, API_PATCH = tonumber(API_MAJOR), tonumber(API_MINOR), tonumber(API_PATCH)
 
 --checks if the given parser has a valid version number
 local function check_api_version(parser, id)
@@ -20,6 +21,7 @@ local function check_api_version(parser, id)
     local version = parser.api_version or "1.0.0"
 
     local major, minor = version:match("(%d+)%.(%d+)")
+    major, minor = tonumber(major), tonumber(minor)
 
     if not major or not minor then
         return msg.error(("%s: invalid version number, expected v%d.%d.x, got v%s"):format(id, API_MAJOR, API_MINOR, version))

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -18,7 +18,7 @@ local function check_api_version(parser, id)
         parser.api_version = parser.version
     end
 
-    local version = parser.api_version or "1.0.0"
+    local version = parser.api_version
 
     local major, minor = version:match("(%d+)%.(%d+)")
     major, minor = tonumber(major), tonumber(minor)

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -11,13 +11,13 @@ local parser_API = require 'modules.apis.parser'
 local API_MAJOR, API_MINOR, API_PATCH = g.API_VERSION:match("(%d+)%.(%d+)%.(%d+)")
 
 --checks if the given parser has a valid version number
-local function check_api_version(parser, file)
+local function check_api_version(parser, id)
     if parser.version then
-        msg.warn(('%q: use of the `version` field is deprecated - use `api_version` instead'):format(file))
+        msg.warn(('%q: use of the `version` field is deprecated - use `api_version` instead'):format(id))
         parser.api_version = parser.version
     end
 
-    local version = parser.version or "1.0.0"
+    local version = parser.api_version or "1.0.0"
 
     local major, minor = version:match("(%d+)%.(%d+)")
 

--- a/modules/addons.lua
+++ b/modules/addons.lua
@@ -13,7 +13,7 @@ local API_MAJOR, API_MINOR, API_PATCH = g.API_VERSION:match("(%d+)%.(%d+)%.(%d+)
 --checks if the given parser has a valid version number
 local function check_api_version(parser, id)
     if parser.version then
-        msg.warn(('%q: use of the `version` field is deprecated - use `api_version` instead'):format(id))
+        msg.warn(('%s: use of the `version` field is deprecated - use `api_version` instead'):format(id))
         parser.api_version = parser.version
     end
 
@@ -22,11 +22,11 @@ local function check_api_version(parser, id)
     local major, minor = version:match("(%d+)%.(%d+)")
 
     if not major or not minor then
-        return msg.error("Invalid version number")
+        return msg.error(("%s: invalid version number, expected v%d.%d.x, got v%s"):format(id, API_MAJOR, API_MINOR, version))
     elseif major ~= API_MAJOR then
-        return msg.error("parser", parser.name, "has wrong major version number, expected", ("v%d.x.x"):format(API_MAJOR), "got", 'v'..version)
+        return msg.error(("%s has wrong major version number, expected v%d.x.x, got, v%s"):format(id, API_MAJOR, version))
     elseif minor > API_MINOR then
-        msg.warn("parser", parser.name, "has newer minor version number than API, expected", ("v%d.%d.x"):format(API_MAJOR, API_MINOR), "got", 'v'..version)
+        msg.warn(("%s has newer minor version number than API, expected v%d.%d.x, got v%s"):format(id, API_MAJOR, API_MINOR, version))
     end
     return true
 end
@@ -164,6 +164,7 @@ local function load_external_addons()
 end
 
 return {
+    check_api_version = check_api_version,
     load_internal_parsers = load_internal_parsers,
     load_external_addons = load_external_addons
 }

--- a/modules/cache.lua
+++ b/modules/cache.lua
@@ -3,41 +3,137 @@
 --------------------------------------------------------------------------------------------------------
 --------------------------------------------------------------------------------------------------------
 
+local msg = require 'mp.msg'
+local utils = require 'mp.utils'
+
 local g = require 'modules.globals'
+local fb_utils = require 'modules.utils'
 
---metatable of methods to manage the cache
-local __cache = {}
+local function get_keys(t)
+    local keys = {}
+    for key in pairs(t) do
+        table.insert(keys, key)
+    end
+    return keys
+end
 
-__cache.cached_values = {
-    "directory", "directory_label", "list", "selected", "selection", "parser", "empty_text", "co"
+local cache = {
+    cache = setmetatable({}, {__mode = 'kv'}),
+    traversal_stack = {},
+    history = {},
+    cached_values = {
+        "directory", "directory_label", "list", "selected", "selection", "parser", "empty_text", "co"
+    },
+    dangling_refs = {},
 }
 
---inserts latest state values onto the cache stack
-function __cache:push()
-    local t = {}
+function cache:print_debug_info()
+    local cache_keys = get_keys(self.cache)
+    msg.verbose('Printing cache debug info')
+    msg.verbose('cache size:', #cache_keys)
+    msg.debug(utils.to_string(cache_keys))
+    msg.trace(utils.to_string(self.cache[cache_keys[#cache_keys]]))
+
+    msg.verbose('traversal_stack size:', #self.traversal_stack)
+    msg.debug(utils.to_string(fb_utils.list.map(self.traversal_stack, function(ref) return ref.directory end)))
+
+    msg.verbose('history size:', #self.history)
+    msg.debug(utils.to_string(fb_utils.list.map(self.history, function(ref) return ref.directory end)))
+end
+
+function cache:replace_dangling_refs(directory, ref)
+    for _, v in ipairs(self.traversal_stack) do
+        if v.directory == directory then
+            v.ref = ref
+            self.dangling_refs[directory] = nil
+        end
+    end
+    for _, v in ipairs(self.history) do
+        if v.directory == directory then
+            v.ref = ref
+            self.dangling_refs[directory] = nil
+        end
+    end
+end
+
+function cache:add_current_state()
+    local directory = g.state.directory
+    if directory == nil then return end
+
+    local t = self.cache[directory] or {}
     for _, value in ipairs(self.cached_values) do
         t[value] = g.state[value]
     end
-    table.insert(self, t)
+
+    self.cache[directory] = t
+    if self.dangling_refs[directory] then
+        self:replace_dangling_refs(directory, t)
+    end
 end
 
-function __cache:pop()
-    table.remove(self)
+-- Creates a reference to the cache of a particular directory to prevent it
+-- from being garbage collected.
+function cache:get_cache_ref(directory)
+   return {
+        directory = directory,
+        ref = self.cache[directory],
+   }
 end
 
-function __cache:apply()
-    local t = self[#self]
+function cache:append_history()
+    self:add_current_state()
+    local history_size = #self.history
+
+    -- We don't want to have the same directory in the history over and over again.
+    if history_size > 0 and self.history[history_size].directory == g.state.directory then return end
+
+    table.insert(self.history, self:get_cache_ref(g.state.directory))
+    if (history_size + 1) > 100 then table.remove(self.history, 1) end
+end
+
+function cache:in_cache(directory)
+    return self.cache[directory] ~= nil
+end
+
+function cache:apply(directory)
+    directory = directory or g.state.directory
+    local t = self.cache[directory]
+    if not t then return false end
+
+    msg.verbose('applying cache for', directory)
+
     for _, value in ipairs(self.cached_values) do
+        msg.debug('setting', value, 'to', t[value])
         g.state[value] = t[value]
     end
+
+    return true
 end
 
-function __cache:clear()
-    for i = 1, #self do
-        self[i] = nil
+function cache:push()
+    local stack_size = #self.traversal_stack
+    if stack_size > 0 and self.traversal_stack[stack_size].directory == g.state.directory then return end
+    table.insert(self.traversal_stack, self:get_cache_ref(g.state.directory))
+end
+
+function cache:pop()
+    table.remove(self.traversal_stack)
+end
+
+function cache:clear_traversal_stack()
+    self.traversal_stack = {}
+end
+
+function cache:clear()
+    self.cache = setmetatable({}, {__mode = 'kv'})
+    for _, v in ipairs(self.traversal_stack) do
+        v.ref = nil
+        self.dangling_refs[v.directory] = true
+    end
+    for _, v in ipairs(self.history) do
+        v.ref = nil
+        self.dangling_refs[v.directory] = true
     end
 end
-
-local cache = setmetatable({}, { __index = __cache })
 
 return cache

--- a/modules/controls.lua
+++ b/modules/controls.lua
@@ -71,8 +71,10 @@ function controls.escape()
 end
 
 --opens a specific directory
-function controls.browse_directory(directory)
+function controls.browse_directory(directory, open_browser)
     if not directory then return end
+    if open_browser == nil then open_browser = true end
+
     directory = mp.command_native({"expand-path", directory}) or ''
     -- directory = join_path( mp.get_property("working-directory", ""), directory )
 
@@ -81,7 +83,7 @@ function controls.browse_directory(directory)
 
     directory = fb_utils.resolve_directory_mapping(directory)
     movement.goto_directory(directory)
-    controls.open()
+    if open_browser then controls.open() end
 end
 
 return controls

--- a/modules/controls.lua
+++ b/modules/controls.lua
@@ -82,8 +82,9 @@ function controls.browse_directory(directory, open_browser)
     msg.verbose('recieved directory from script message: '..directory)
 
     directory = fb_utils.resolve_directory_mapping(directory)
-    movement.goto_directory(directory)
+    local co = movement.goto_directory(directory)
     if open_browser then controls.open() end
+    return co
 end
 
 return controls

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -9,7 +9,7 @@ local globals = {}
 local o = require 'modules.options'
 
 --sets the version for the file-browser API
-globals.API_VERSION = "1.6.0"
+globals.API_VERSION = "1.7.0"
 
 --gets the current platform (only works in mpv v0.36+)
 globals.PLATFORM = mp.get_property_native('platform')

--- a/modules/keybinds.lua
+++ b/modules/keybinds.lua
@@ -10,6 +10,7 @@ local utils = require 'mp.utils'
 local o = require 'modules.options'
 local g = require 'modules.globals'
 local fb_utils = require 'modules.utils'
+local addons = require 'modules.addons'
 local playlist = require 'modules.playlist'
 local controls = require 'modules.controls'
 local movement = require 'modules.navigation.directory-movement'
@@ -233,6 +234,8 @@ end
 --inserting the custom keybind into the keybind array for declaration when file-browser is opened
 --custom keybinds with matching names will overwrite eachother
 local function insert_custom_keybind(keybind)
+    if not addons.check_api_version(keybind, 'keybind '..keybind.name) then return end
+
     --we'll always save the keybinds as either an array of command arrays or a function
     if type(keybind.command) == "table" and type(keybind.command[1]) ~= "table" then
         keybind.command = {keybind.command}

--- a/modules/keybinds.lua
+++ b/modules/keybinds.lua
@@ -234,6 +234,8 @@ end
 --inserting the custom keybind into the keybind array for declaration when file-browser is opened
 --custom keybinds with matching names will overwrite eachother
 local function insert_custom_keybind(keybind)
+    -- api checking for the keybinds is optional, so set to a valid version if it does not exist
+    keybind.api_version = keybind.api_version or '1.0.0'
     if not addons.check_api_version(keybind, 'keybind '..keybind.name) then return end
 
     --we'll always save the keybinds as either an array of command arrays or a function

--- a/modules/navigation/directory-movement.lua
+++ b/modules/navigation/directory-movement.lua
@@ -35,19 +35,19 @@ end
 --the base function for moving to a directory
 function directory_movement.goto_directory(directory)
     g.state.directory = directory
-    scanning.rescan(false)
+    return scanning.rescan(false)
 end
 
 --loads the root list
 function directory_movement.goto_root()
     msg.verbose('jumping to root')
-    directory_movement.goto_directory("")
+    return directory_movement.goto_directory("")
 end
 
 --switches to the directory of the currently playing file
 function directory_movement.goto_current_dir()
     msg.verbose('jumping to current directory')
-    directory_movement.goto_directory(g.current_file.directory)
+    return directory_movement.goto_directory(g.current_file.directory)
 end
 
 --moves up a directory
@@ -55,8 +55,7 @@ function directory_movement.up_dir()
     local parent_dir = g.state.directory:match("^(.-/+)[^/]+/*$") or ""
 
     if o.skip_protocol_schemes and parent_dir:find("^(%a[%w+-.]*)://$") then
-        directory_movement.goto_root()
-        return;
+        return directory_movement.goto_root()
     end
 
     g.state.directory = parent_dir
@@ -79,7 +78,7 @@ function directory_movement.down_dir()
 
     --we can make some assumptions about the next directory label when moving up or down
     if g.state.directory_label then g.state.directory_label = g.state.directory_label..(current.label or current.name) end
-    scanning.rescan(not redirected)
+    return scanning.rescan(not redirected)
 end
 
 return directory_movement

--- a/modules/navigation/scanning.lua
+++ b/modules/navigation/scanning.lua
@@ -148,7 +148,8 @@ local function update_list(moving_adjacent)
 end
 
 --rescans the folder and updates the list
-local function update(moving_adjacent)
+--returns the coroutine for the new parse operation
+local function rescan(moving_adjacent)
     --we can only make assumptions about the directory label when moving from adjacent directories
     if not moving_adjacent then clear_non_adjacent_state() end
 
@@ -159,16 +160,17 @@ local function update(moving_adjacent)
 
     --the directory is always handled within a coroutine to allow addons to
     --pause execution for asynchronous operations
-    fb_utils.coroutine.run(function()
-        g.state.co = coroutine.running()
+    g.state.co = fb_utils.coroutine.queue(function()
         update_list(moving_adjacent)
         if g.state.empty_text == "~" then g.state.empty_text = "empty directory" end
         ass.update_ass()
     end)
+
+    return g.state.co
 end
 
 return {
-    rescan = update,
+    rescan = rescan,
     scan_directory = parse_directory,
     choose_and_parse = choose_and_parse,
 }

--- a/modules/navigation/scanning.lua
+++ b/modules/navigation/scanning.lua
@@ -12,7 +12,7 @@ local parse_state_API = require 'modules.apis.parse-state'
 
 local function clear_non_adjacent_state()
     g.state.directory_label = nil
-    cache:clear()
+    cache:clear_traversal_stack()
 end
 
 --parses the given directory or defers to the next parser if nil is returned
@@ -86,11 +86,9 @@ local function update_list(moving_adjacent)
     g.state.selection = {}
 
     --loads the current directry from the cache to save loading time
-    --there will be a way to forcibly reload the current directory at some point
-    --the cache is in the form of a stack, items are taken off the stack when the dir moves up
-    if cache[1] and cache[#cache].directory == g.state.directory then
+    if cache:in_cache(g.state.directory) then
         msg.verbose('found directory in cache')
-        cache:apply()
+        cache:apply(g.state.directory)
         g.state.prev_directory = g.state.directory
         return
     end
@@ -106,11 +104,11 @@ local function update_list(moving_adjacent)
     end
 
     --apply fallbacks if the scan failed
-    if not list and cache[1] then
+    if not list and cache:in_cache(g.state.prev_directory) then
         --switches settings back to the previously opened directory
         --to the user it will be like the directory never changed
         msg.warn("could not read directory", g.state.directory)
-        cache:apply()
+        cache:apply(g.state.prev_directory)
         return
     elseif not list then
         --opens the root instead
@@ -150,6 +148,8 @@ end
 --rescans the folder and updates the list
 --returns the coroutine for the new parse operation
 local function rescan(moving_adjacent)
+    if moving_adjacent == nil then moving_adjacent = 0 end
+
     --we can only make assumptions about the directory label when moving from adjacent directories
     if not moving_adjacent then clear_non_adjacent_state() end
 
@@ -163,6 +163,12 @@ local function rescan(moving_adjacent)
     g.state.co = fb_utils.coroutine.queue(function()
         update_list(moving_adjacent)
         if g.state.empty_text == "~" then g.state.empty_text = "empty directory" end
+
+        cache:append_history()
+        if type(moving_adjacent) == 'number' and moving_adjacent < 0 then cache:pop()
+        else cache:push() end
+        if not cache.traversal_stack[1] then cache:push() end
+
         ass.update_ass()
     end)
 

--- a/modules/parsers/file.lua
+++ b/modules/parsers/file.lua
@@ -8,6 +8,7 @@ local utils = require 'mp.utils'
 local file_parser = {
     name = "file",
     priority = 110,
+    api_version = '1.0.0',
 }
 
 --try to parse any directory except for the root

--- a/modules/parsers/root.lua
+++ b/modules/parsers/root.lua
@@ -7,6 +7,7 @@ local g = require 'modules.globals'
 local root_parser = {
     name = "root",
     priority = math.huge,
+    api_version = '1.0.0',
 }
 
 function root_parser:can_parse(directory)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -48,6 +48,16 @@ function fb_utils.list.some(t, fn)
     return false
 end
 
+-- Creates a new table populated with the results of
+-- calling a provided function on every element in t.
+function fb_utils.list.map(t, fn)
+    local new_t = {}
+    for i, v in ipairs(t) do
+        new_t[i] = fn(v, i, t)
+    end
+    return new_t
+end
+
 --prints an error message and a stack trace
 --accepts an error object and optionally a coroutine
 --can be passed directly to xpcall

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -119,6 +119,17 @@ function fb_utils.coroutine.sleep(n)
     coroutine.yield()
 end
 
+
+--Runs the given function in a coroutine, passing through any additional arguments.
+--Does not run the coroutine immediately, instead it ques the coroutine to run when the thread is next idle.
+--Returns the coroutine object so that the caller can act on it before it is run.
+function fb_utils.coroutine.queue(fn, ...)
+    local co = coroutine.create(fn)
+    local args = table.pack(...)
+    mp.add_timeout(0, function() fb_utils.coroutine.resume_err(co, table.unpack(args, 1, args.n)) end)
+    return co
+end
+
 --runs the given function in a coroutine, passing through any additional arguments
 --this is for triggering an event in a coroutine
 function fb_utils.coroutine.run(fn, ...)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -10,8 +10,8 @@ local utils = require 'mp.utils'
 local o = require 'modules.options'
 local g = require 'modules.globals'
 
-local success, input = pcall(require, "user-input-module")
-if not success then input = nil end
+local input_loaded, input = pcall(require, 'mp.input')
+local user_input_loaded, user_input = pcall(require, 'user-input-module')
 
 --creates a table for the API functions
 --adds one metatable redirect to prevent addon authors from accidentally breaking file-browser
@@ -378,7 +378,8 @@ function fb_utils.evaluate_string(str, name)
     env.msg = fb_utils.redirect_table(msg)
     env.utils = fb_utils.redirect_table(utils)
     env.fb = fb_utils.redirect_table(fb_utils)
-    env.input = input and fb_utils.redirect_table(input)
+    env.input = input_loaded and fb_utils.redirect_table(input)
+    env.user_input = user_input_loaded and fb_utils.redirect_table(user_input)
 
     local chunk, err
     if setfenv then


### PR DESCRIPTION
- [x] Bump version number.
- [x] Allow browse_directory to be used without opening the browser.
- [x] Switch `version` field to `api_version` to reduce confusion.
- [x] Deprecate `version`.
- [x] Switch addons over to use new field name.
- [x] Update mpv-v0. 31 branch to read `api_version` field.
- [x] Add coroutine.queue from #80
- [x] Add `api_version` field to keybinds to unify the APIs (started in #80).
- [x] Fix regression with cache.
- [x] Add support for mp.input when evaluating expressions. 

Resolves #95