### PR TITLE
Bump Addon API to v1.7.1

### DIFF
--- a/docs/addons.md
+++ b/docs/addons.md
@@ -1,4 +1,4 @@
-# How to Write an Addon - API v1.7.0
+# How to Write an Addon - API v1.7.1
 
 Addons provide ways for file-browser to parse non-native directory structures. This document describes how one can create their own custom addon.
 
@@ -859,8 +859,9 @@ Used for custom-keybind filtering.
 
 The current directory open in the browser.
 
-#### `fb.get_dvd_device(): string`
+#### ~~`fb.get_dvd_device(): string`~~
 
+*DEPRECATED*.
 The current dvd-device as reported by mpv's `dvd-device` property.
 Formatted to work with file-browser.
 

--- a/modules/apis/fb.lua
+++ b/modules/apis/fb.lua
@@ -1,3 +1,4 @@
+local mp = require 'mp'
 local msg = require 'mp.msg'
 local utils = require 'mp.utils'
 
@@ -106,7 +107,6 @@ function fb.get_sub_extensions() return fb.copy_table(g.sub_extensions) end
 function fb.get_audio_extensions() return fb.copy_table(g.audio_extensions) end
 function fb.get_parseable_extensions() return fb.copy_table(g.parseable_extensions) end
 function fb.get_state() return fb.copy_table(g.state) end
-function fb.get_dvd_device() return g.dvd_device end
 function fb.get_parsers() return fb.copy_table(g.parsers) end
 function fb.get_root() return fb.copy_table(g.root) end
 function fb.get_directory() return g.state.directory end
@@ -118,6 +118,13 @@ function fb.get_selected_index() return g.state.selected end
 function fb.get_selected_item() return fb.copy_table(g.state.list[g.state.selected]) end
 function fb.get_open_status() return not g.state.hidden end
 function fb.get_parse_state(co) return g.parse_states[co or coroutine.running() or ""] end
+
+-- deprecated
+function fb.get_dvd_device()
+    local dvd_device = mp.get_property('dvd-device')
+    if not dvd_device then return nil end
+    return fb_utils.fix_path(dvd_device, true)
+end
 
 function fb.set_empty_text(str)
     g.state.empty_text = str

--- a/modules/globals.lua
+++ b/modules/globals.lua
@@ -9,7 +9,7 @@ local globals = {}
 local o = require 'modules.options'
 
 --sets the version for the file-browser API
-globals.API_VERSION = "1.7.0"
+globals.API_VERSION = "1.7.1"
 
 --gets the current platform (only works in mpv v0.36+)
 globals.PLATFORM = mp.get_property_native('platform')


### PR DESCRIPTION
fix and deprecate `fb.get_dvd_device`